### PR TITLE
Add a method to list the cda files in a repository

### DIFF
--- a/cpf-core/src/main/java/pt/webdetails/cpf/repository/IRepositoryAccess.java
+++ b/cpf-core/src/main/java/pt/webdetails/cpf/repository/IRepositoryAccess.java
@@ -74,7 +74,7 @@ public interface IRepositoryAccess {
 
     public abstract SaveFileStatus copySolutionFile(String fromFilePath,
             String toFilePath) throws IOException;
-    
+
     public abstract String getSolutionPath(String path);
 
     /*
@@ -82,24 +82,25 @@ public interface IRepositoryAccess {
      * Best would be to remove the whole "solution" concept
      */
     public abstract IRepositoryFile getRepositoryFile(String path, FileAccess fileAccess);
-    
+
     public abstract void setUserSession(IUserSession userSession);
-    
+
     public abstract void setPlugin(Plugin plugin);
-    
+
     public abstract IRepositoryFile getSettingsFile(String path, FileAccess fileAccess);
     public abstract String getSettingsResourceAsString(String settingsPath)
             throws IOException;
-    
+
     /*
      * TODO: This should really be getSettingsFiles ? make those two methods consistent
      */
     @Deprecated
     public abstract IRepositoryFile[] getPluginFiles(String baseDir, FileAccess accessMode);
-    
+
+    public abstract IRepositoryFile[] listRepositoryFiles();
 
      public abstract IRepositoryFile[] getSettingsFileTree(final String dir, final String fileExtensions, FileAccess access);
-    
+
 
     @Deprecated
     public abstract String getJqueryFileTree(final String dir, final String fileExtensions, final String access) ;

--- a/cpf-pentaho/src/main/java/pt/webdetails/cpf/repository/PentahoRepositoryAccess.java
+++ b/cpf-pentaho/src/main/java/pt/webdetails/cpf/repository/PentahoRepositoryAccess.java
@@ -3,10 +3,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 package pt.webdetails.cpf.repository;
 
-import com.sun.syndication.io.impl.PluginManager;
 import java.io.File;
 import java.io.FileNotFoundException;
-
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -16,28 +14,12 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.dom4j.Document;
-import org.pentaho.platform.api.engine.IAclSolutionFile;
-import org.pentaho.platform.api.engine.IFileFilter;
-import org.pentaho.platform.api.engine.IPentahoAclEntry;
-import org.pentaho.platform.api.engine.IPentahoSession;
-import org.pentaho.platform.api.engine.IPluginManager;
-import org.pentaho.platform.api.engine.ISolutionFile;
-import org.pentaho.platform.api.engine.ISolutionFilter;
-import org.pentaho.platform.api.engine.IUserDetailsRoleListService;
-import org.pentaho.platform.api.engine.PentahoAccessControlException;
-import org.pentaho.platform.api.repository.ISolutionRepository;
-import org.pentaho.platform.api.repository.ISolutionRepositoryService;
-import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
-import org.pentaho.platform.engine.core.system.PentahoSystem;
-import org.pentaho.platform.engine.core.system.UserSession;
 import org.pentaho.platform.engine.security.SecurityHelper;
 import org.springframework.security.Authentication;
 import org.springframework.security.GrantedAuthority;
@@ -46,6 +28,9 @@ import org.springframework.security.providers.anonymous.AnonymousAuthenticationT
 import pt.webdetails.cpf.PluginSettings;
 import pt.webdetails.cpf.impl.DefaultRepositoryFile;
 import pt.webdetails.cpf.plugin.Plugin;
+import pt.webdetails.cpf.repository.BaseRepositoryAccess.FileAccess;
+import pt.webdetails.cpf.repository.BaseRepositoryAccess.SaveFileStatus;
+import pt.webdetails.cpf.repository.PentahoRepositoryAccess.ExtensionFilter;
 import pt.webdetails.cpf.session.IUserSession;
 import pt.webdetails.cpf.session.PentahoSession;
 
@@ -63,7 +48,7 @@ public class PentahoRepositoryAccess extends BaseRepositoryAccess implements IRe
   }
   private static Log logger = LogFactory.getLog(PentahoRepositoryAccess.class);
 
-  /* 
+  /*
    * This wiill be used for privileged access to the repository
    */
   private static IPentahoSession getAdminSession() {
@@ -329,30 +314,30 @@ public class PentahoRepositoryAccess extends BaseRepositoryAccess implements IRe
     return new PentahoRepositoryFile(getSolutionRepository().getSolutionFile(path, fileAccess.ordinal()));
   }
 
-  
+
   private IPentahoSession getPentahoSession(){
-    IPentahoSession session = null;    
+    IPentahoSession session = null;
     if (userSession != null)
       session = ((PentahoSession) userSession).getPentahoSession();
     else
       session = PentahoSessionHolder.getSession();
     return session;
   }
-  
+
   @Override
   public String getJqueryFileTree(String dir, String fileExtensions, String access) {
-      
+
     return RepositoryFileExplorer.toJQueryFileTree(dir, getFileList(dir, fileExtensions, access, getPentahoSession()));
   }
 
-  
-  
+
+
   @Override
   public String getJSON(String dir, String fileExtensions, String access) {
     return RepositoryFileExplorer.toJSON(dir, getFileList(dir, fileExtensions, access, getPentahoSession()));
   }
 
-  
+
   @Override
   public IRepositoryFile[] getSettingsFileTree(final String dir, final String fileExtensions, FileAccess access) {
     IPluginManager pluginManager = PentahoSystem.get(IPluginManager.class, getAdminSession());
@@ -371,16 +356,16 @@ public class PentahoRepositoryAccess extends BaseRepositoryAccess implements IRe
         return name.endsWith("." + fileExtensions);
       }
     });
-    
+
     IRepositoryFile[] result = new IRepositoryFile[fileArray.length];
     int i = 0;
     for (File resultFile : fileArray)
       result[i++] = new DefaultRepositoryFile(resultFile);
-    
+
     return result;
-    
+
   }
-  
+
   @Override
   public IRepositoryFile[] getPluginFiles(String baseDir, FileAccess fa) {
     final IRepositoryFileFilter irff = plugin.getPluginFileFilter();
@@ -496,6 +481,11 @@ public class PentahoRepositoryAccess extends BaseRepositoryAccess implements IRe
     }
 
     return list.toArray(new IRepositoryFile[list.size()]);
+  }
+
+  @Override
+  public IRepositoryFile[] listRepositoryFiles() {
+    return getFileList("/", "cda", "READ", userSession);
   }
 
   public static int toResourceAction(FileAccess f) {

--- a/cpf-standalone/src/test/java/pt/webdetails/cpf/test/VfsRepositoryTest.java
+++ b/cpf-standalone/src/test/java/pt/webdetails/cpf/test/VfsRepositoryTest.java
@@ -2,25 +2,27 @@ package pt.webdetails.cpf.test;
 
 
 import junit.framework.TestCase;
+
 import org.apache.commons.vfs.FileObject;
 import org.apache.commons.vfs.Selectors;
+
 import pt.webdetails.cpf.repository.BaseRepositoryAccess.FileAccess;
-import pt.webdetails.cpf.repository.VfsRepositoryAccess;
 import pt.webdetails.cpf.repository.BaseRepositoryAccess.SaveFileStatus;
 import pt.webdetails.cpf.repository.IRepositoryFile;
+import pt.webdetails.cpf.repository.VfsRepositoryAccess;
 
 
 
 public class VfsRepositoryTest extends TestCase {
-	
+
 	private VfsRepositoryAccessForTests repository;
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
 		this.repository = new VfsRepositoryAccessForTests("res:repository", "res:settings");
 	}
-        
-        
+
+
 	public void testBasicRepo() {
 		try {
                         repository.publishFile("testsolutionfile", "testcontent", true);
@@ -34,7 +36,7 @@ public class VfsRepositoryTest extends TestCase {
 			e.printStackTrace();
 			fail();
 		}
-		
+
 	}
         public void testFolderCreation(){
             try{
@@ -44,14 +46,14 @@ public class VfsRepositoryTest extends TestCase {
                 assertTrue(folderCeption);
                 boolean doNothing = repository.createFolder("testFolderCreation");//do nothing because folder exists
                 assertTrue(doNothing);
-                
+
                 //cleanup after the test
                 repository.removeUnsafe(".");
             }catch(Exception e){
             e.printStackTrace();
             fail();
-        }    
-            
+        }
+
         }
         public void testResourceExists(){
             try{
@@ -59,7 +61,7 @@ public class VfsRepositoryTest extends TestCase {
                 boolean exists = repository.resourceExists("testFolderCreation");
                 boolean notExists = repository.resourceExists("IAmNotAFolder!");
                 assertTrue(exists&&!notExists);
-                
+
                 //cleanup after the test
                 repository.removeUnsafe(".");
             }catch(Exception e){
@@ -74,10 +76,10 @@ public class VfsRepositoryTest extends TestCase {
             repository.publishFile("fileName", "fileContent", true);
             boolean publishOverwriteFalse = SaveFileStatus.FAIL==repository.publishFile("fileName", "contentOverwrite", false);//overwrite = false
             assertTrue(publishOverwriteFalse);
-            repository.publishFile("fileToOverwrite", "I shall be overwritten", false);//creates a file wich will be overwriten 
+            repository.publishFile("fileToOverwrite", "I shall be overwritten", false);//creates a file wich will be overwriten
             boolean publishOverwriteTrue = SaveFileStatus.OK==repository.publishFile("fileToOverwrite", "Overwrite Sucessfull!", true);//overwrites a file
             assertTrue(publishOverwriteTrue);
-             
+
             //cleanup after the test
             repository.removeUnsafe(".");
         } catch (Exception e) {
@@ -87,26 +89,26 @@ public class VfsRepositoryTest extends TestCase {
         }
         public void testCopyFile(){
         try {
-            
+
             repository.publishFile("from", "My contents shall be copied to the other file", false);
             repository.publishFile("to", "no matter, these contents will be deleted", false);
-            
+
             boolean copy = SaveFileStatus.OK==repository.copySolutionFile("from", "to");
-            
+
             assertTrue(copy);//was copied
             assertEquals("My contents shall be copied to the other file",repository.getResourceAsString("to"));//the content was correctly copied
             boolean createsFileTo = SaveFileStatus.OK==repository.copySolutionFile("from", "createdOnCopy");//creates the destination file
             assertTrue(createsFileTo);
             boolean cantFindFile = SaveFileStatus.FAIL==repository.copySolutionFile("nonExistingFile", "to");//wont find nonExistingFile
             assertTrue(cantFindFile);
-         
+
             //cleanup after the test
             repository.removeUnsafe(".");
         } catch (Exception e) {
             e.printStackTrace();
             fail();
         }
-        }  
+        }
         public void testFileRemoval(){
             try{
                 repository.publishFile("fileToDelete", "", true);
@@ -118,7 +120,7 @@ public class VfsRepositoryTest extends TestCase {
                 repository.publishFile("cantDeleteMe/imSafeHere","",true);
                 boolean cantRemoveFolderWithFiles = !repository.removeFileIfExists("cantDeleteMe");//wont remove a folder with files
                 assertTrue(cantRemoveFolderWithFiles);
-                  
+
                 //cleanup after the test
                 repository.removeUnsafe(".");
             }catch(Exception e){
@@ -128,8 +130,8 @@ public class VfsRepositoryTest extends TestCase {
         }
         public void testGetRepositoryFile(){
             try{
-               repository.publishFile("repoFolder/repoFile", "repo file content", true); 
-               
+               repository.publishFile("repoFolder/repoFile", "repo file content", true);
+
                IRepositoryFile repoFile = repository.getRepositoryFile("repoFolder/repoFile", FileAccess.READ);
                IRepositoryFile repoFolder = repository.getRepositoryFile("repoFolder", FileAccess.READ);
                IRepositoryFile nonExistent = repository.getRepositoryFile("wrongName", FileAccess.READ);
@@ -140,13 +142,13 @@ public class VfsRepositoryTest extends TestCase {
                assertTrue(repoFolder.isDirectory());//is directory
                assertFalse(repoFolder.isRoot());//not root
                assertTrue(repoFolder.listFiles().length>0);//folder has children
-               
+
                assertFalse(nonExistent.exists());
-               
-               
-               
+
+
+
             //cleanup after the test
-            repository.removeUnsafe(".");  
+            repository.removeUnsafe(".");
             }catch(Exception e){
             e.printStackTrace();
             fail();
@@ -154,10 +156,10 @@ public class VfsRepositoryTest extends TestCase {
         }
         public void testGetSettingsFile(){
             try{
-               
+
              assertTrue(repository.getSettingsFile("testFile", FileAccess.READ).exists());//this one exists
              assertFalse(repository.getSettingsFile("random", FileAccess.READ).exists());//this one doesnt
-             
+
 
             }catch(Exception e){
             e.printStackTrace();
@@ -172,12 +174,12 @@ public class VfsRepositoryTest extends TestCase {
                IRepositoryFile[] files1 = repository.getSettingsFileTree("testFolder", "anotherExtension", FileAccess.READ);
                IRepositoryFile[] files2 = repository.getSettingsFileTree("testFolder", "notAnExtension", FileAccess.READ);
                IRepositoryFile[] files3 = repository.getSettingsFileTree("notEvenAFolder", "extension", FileAccess.READ);
-               
+
                assertTrue(files0.length>0);
                assertTrue(files1.length>0);
                assertFalse(files2.length>0);
                assertFalse(files3.length>0);
-               
+
             }catch(Exception e){
             e.printStackTrace();
             fail();
@@ -188,18 +190,18 @@ public class VfsRepositoryTest extends TestCase {
               //XXX created manually
                IRepositoryFile[] files = repository.getPluginFiles("pluginDir", FileAccess.READ);
                IRepositoryFile[] files1 = repository.getPluginFiles("wrongDir", FileAccess.READ);
-               
-               
+
+
                assertTrue(files.length>0);
                assertFalse(files1.length>0);
-               
-               
-               
+
+
+
             }catch(Exception e){
             e.printStackTrace();
             fail();
         }
-        } 
+        }
         public void testFileUnsafeRemoval(){
             try{
                 repository.publishFile("folderToDelete/anotherFolder/fileToDelete", "", true);
@@ -214,24 +216,29 @@ public class VfsRepositoryTest extends TestCase {
             e.printStackTrace();
             fail();
         }
-        }      
+        }
+
+        public void testListRepositoryFiles() {
+            IRepositoryFile[] listRepositoryFiles = repository.listRepositoryFiles();
+            assertEquals(0, listRepositoryFiles.length);
+        }
 }
 
 
 
  class  VfsRepositoryAccessForTests extends VfsRepositoryAccess {
-      
-     
-     
+
+
+
      public VfsRepositoryAccessForTests(String repo,String settings){
          super(repo,settings);
      }
-     
+
           /**
            * Please do note this will remove the folder and all subfolders and files
            * Used for testing purposes only
            * @param file
-           * @return 
+           * @return
            */
           public int removeUnsafe(String file){
               try {


### PR DESCRIPTION
The listRepositoryFiles method returns an array of files in the root
of the repository which end in the ".cda" file extension.

I'm not at all sure that the implementation in PentahoRepositoryAccess.java is correct - let me know if there's a better way and I'll fix it up.
