### PR TITLE
Don't use the test VfsRepository* classes

### DIFF
--- a/cpf-standalone/src/main/java/pt/webdetails/cpf/repository/VfsRepositoryAccess.java
+++ b/cpf-standalone/src/main/java/pt/webdetails/cpf/repository/VfsRepositoryAccess.java
@@ -1,7 +1,7 @@
 package pt.webdetails.cpf.repository;
 
-import pt.webdetails.cpk.testUtils.VfsRepositoryFile;
-import pt.webdetails.cpk.testUtils.VfsRepositoryAccess;
+import pt.webdetails.cpf.repository.VfsRepositoryFile;
+import pt.webdetails.cpf.repository.VfsRepositoryAccess;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/cpf-standalone/src/main/java/pt/webdetails/cpf/repository/VfsRepositoryFile.java
+++ b/cpf-standalone/src/main/java/pt/webdetails/cpf/repository/VfsRepositoryFile.java
@@ -1,7 +1,6 @@
 package pt.webdetails.cpf.repository;
 
 
-import pt.webdetails.cpk.testUtils.VfsRepositoryFile;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/cpf-standalone/src/test/java/pt/webdetails/cpf/test/VfsRepositoryTest.java
+++ b/cpf-standalone/src/test/java/pt/webdetails/cpf/test/VfsRepositoryTest.java
@@ -6,7 +6,7 @@ import junit.framework.TestCase;
 import org.apache.commons.vfs.FileObject;
 import org.apache.commons.vfs.Selectors;
 import pt.webdetails.cpf.repository.BaseRepositoryAccess.FileAccess;
-import pt.webdetails.cpk.testUtils.VfsRepositoryAccess;
+import pt.webdetails.cpf.repository.VfsRepositoryAccess;
 import pt.webdetails.cpf.repository.BaseRepositoryAccess.SaveFileStatus;
 import pt.webdetails.cpf.repository.IRepositoryFile;
 


### PR DESCRIPTION
Use the classes from the pt.webdetails.cpf.repository package instead of the
ones from pt.webdetails.cpk.testUtils (which do not get added to the cpf-core
jar by default)
