### PR TITLE
[BISERVER-11486] CDF plugin updates for encoding/decoding/reserved chars...

### DIFF
--- a/cpf-pentaho5/src/pt/webdetails/cpf/SimpleContentGenerator.java
+++ b/cpf-pentaho5/src/pt/webdetails/cpf/SimpleContentGenerator.java
@@ -284,7 +284,7 @@ public abstract class SimpleContentGenerator extends BaseContentGenerator {
       String enc = StringUtils.isEmpty( encoding ) ? CharsetHelper.getEncoding() : encoding;
 
       if( getRequestParameters() != null && getRequestParameters().hasParameter( parameter ) ){
-        return URLDecoder.decode( getRequestParameters().getStringParameter( parameter, defaultValue ) );
+        return URLDecoder.decode( getRequestParameters().getStringParameter( parameter, defaultValue ), enc );
       }
       return defaultValue;
     }


### PR DESCRIPTION
... - [cpf-pentaho5] encapsulated parameterProviders.getStringParameter() in new methods within SimpleContentGenerator

```
- [cpf-pentaho5] these methods will become a centralized mean of (transparently) URL decoding the paths
- [all other ctools] content generator classes that extend this SimpleContentGenerator will start calling these methods, instead of parameterProviders.getStringParameter()
```
