### PR TITLE
[CDF-289][REGRESSION] CDF is breaking at runtime in biserver 4.x due to ...

### DIFF
--- a/cpf-pentaho-base/src/pt/webdetails/cpf/persistence/PersistenceEngine.java
+++ b/cpf-pentaho-base/src/pt/webdetails/cpf/persistence/PersistenceEngine.java
@@ -98,7 +98,7 @@ public class PersistenceEngine implements IPersistenceEngine {
 
   private String getOrientPath() {
     return ( this.getClass().getClassLoader() instanceof PluginClassLoader )
-      ? FilenameUtils.normalize( PentahoSystem.getApplicationContext().getSolutionPath( "/system/.orient" ), true ) : ".";
+      ? FilenameUtils.normalize( FilenameUtils.separatorsToUnix( PentahoSystem.getApplicationContext().getSolutionPath( "/system/.orient" ) ) ) : ".";
   }
 
   private void initialize() throws Exception {

--- a/cpf-pentaho/ivy.xml
+++ b/cpf-pentaho/ivy.xml
@@ -22,7 +22,7 @@
     <!--  CORE -->
     <dependency org="pentaho" name="cpf-core"
       rev="${project.revision}" transitive="true" changing="true" conf="default->default"/>
-    <dependency org="commons-io" name="commons-io" rev="2.1"/>
+    <dependency org="commons-io" name="commons-io" rev="1.4"/>
     <dependency org="commons-lang" name="commons-lang" rev="2.6"/>
     <dependency org="javax.servlet" name="servlet-api" rev="2.4"/>
     <dependency org="org.springframework" name="spring-core" rev="2.5.6"/>


### PR DESCRIPTION
...unknown method call FilenameUtils.normalize( filename, unixSeparator )

```
- upgrade of CDF's commons-io ivy dependency from 1.4 to 2.1 solves compile time errors, but in runtime the 4.8 platform still uses it's own ivy dependency of 1.4
- https://commons.apache.org/proper/commons-io/javadocs/api-2.1/org/apache/commons/io/FilenameUtils.html#normalize(java.lang.String,%20boolean) is from commons-io 2.1 and above;
- https://commons.apache.org/proper/commons-io/javadocs/api-1.4/org/apache/commons/io/FilenameUtils.html#normalize(java.lang.String) is the one to call for commons-io 1.4;
```
