### PR TITLE
[CDE-311] MimeType resolver does not handle .svg files, thus sending an ...

### DIFF
--- a/cpf-pentaho5/src/pt/webdetails/cpf/MimeTypeHandler.java
+++ b/cpf-pentaho5/src/pt/webdetails/cpf/MimeTypeHandler.java
@@ -1,0 +1,82 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2014 Pentaho Corporation..  All rights reserved.
+*/
+package pt.webdetails.cpf;
+
+import org.apache.commons.lang.StringUtils;
+import org.pentaho.platform.util.web.MimeHelper;
+import pt.webdetails.cpf.utils.MimeTypes;
+
+/**
+ * This class handles all incoming mime type resolve requests, using the following logic:
+ * <p/>
+ * 1 - call (@link org.pentaho.platform.util.web.MimeHelper ) to resolve the mime type for the provided file extension
+ * <p/>
+ * 2 - if the above class not able to resolve / is not available / whatever,  then fallback to (@link
+ * pt.webdetails.cpf.utils.MimeHelper) for resolve
+ */
+public class MimeTypeHandler {
+
+  public static String getMimeTypeFromFileType( final MimeTypes.FileType fileType ) {
+    return getMimeTypeFromFileType( fileType, null );
+  }
+
+  public static String getMimeTypeFromFileType( final MimeTypes.FileType fileType, String defaultMimeType ) {
+    return getMimeTypeFromExtension( fileType.toString(), defaultMimeType );
+  }
+
+  public static String getMimeTypeFromExtension( final String extension ) {
+    return getMimeTypeFromExtension( extension, null );
+  }
+
+  public static String getMimeTypeFromExtension( final String extension, String defaultMimeType ) {
+
+    if ( StringUtils.isEmpty( extension ) ) {
+      return defaultMimeType;
+    }
+
+    // use org.pentaho.platform.util.web.MimeHelper (expects a dot + file extension)
+    String resolvedMimeType =
+      MimeHelper.getMimeTypeFromExtension( extension.startsWith( "." ) ? extension : "." + extension );
+
+    if ( StringUtils.isEmpty( resolvedMimeType ) ) {
+
+      //fallback to pt.webdetails.cpf.utils.MimeTypes ( does *not* expect a dot )
+      resolvedMimeType =
+        MimeTypes.getMimeTypeFromExt( extension.startsWith( "." ) ? extension.replaceFirst( ".", "" ) : extension );
+    }
+
+    return !StringUtils.isEmpty( resolvedMimeType ) ? resolvedMimeType : defaultMimeType;
+  }
+
+  public static String getMimeTypeFromFileName( final String filename ) {
+    return getMimeTypeFromFileName( filename, null );
+  }
+
+  public static String getMimeTypeFromFileName( final String filename, String defaultMimeType ) {
+
+    // use org.pentaho.platform.util.web.MimeHelper
+    String resolvedMimeType = MimeHelper.getMimeTypeFromFileName( filename );
+
+    if ( StringUtils.isEmpty( resolvedMimeType ) ) {
+
+      //fallback to pt.webdetails.cpf.utils.MimeTypes
+      resolvedMimeType = MimeTypes.getMimeType( filename );
+    }
+
+    return !StringUtils.isEmpty( resolvedMimeType ) ? resolvedMimeType : defaultMimeType;
+  }
+}

--- a/cpf-pentaho5/test-src/log4j.xml
+++ b/cpf-pentaho5/test-src/log4j.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+
+  <appender name="PENTAHOCONSOLE" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.out"/>
+
+    <layout class="org.apache.log4j.PatternLayout">
+      <!-- The default pattern: Date Priority [Category] Message\n -->
+      <param name="ConversionPattern" value="%d{ABSOLUTE} %-5p [%c{1}] %m%n"/>
+    </layout>
+  </appender>
+
+  <!-- ================ -->
+  <!-- Limit categories -->
+  <!-- ================ -->
+
+  <category name="pt.webdetails">
+    <priority value="INFO"/>
+  </category>
+
+  <category name="org">
+    <priority value="ERROR"/>
+  </category>
+
+  <category name="net">
+    <priority value="ERROR"/>
+  </category>
+
+  <root>
+    <!-- out of mem errors can result in Eclipse when this is set to debug  -->
+    <priority value="INFO"/>
+    <appender-ref ref="PENTAHOCONSOLE"/>
+  </root>
+
+
+</log4j:configuration>

--- a/cpf-pentaho5/test-src/pt/webdetails/cpf/MimeTypeHandlerTest.java
+++ b/cpf-pentaho5/test-src/pt/webdetails/cpf/MimeTypeHandlerTest.java
@@ -1,0 +1,99 @@
+/*!
+* Copyright 2002 - 2013 Webdetails, a Pentaho company.  All rights reserved.
+*
+* This software was developed by Webdetails and is provided under the terms
+* of the Mozilla Public License, Version 2.0, or any later version. You may not use
+* this file except in compliance with the license. If you need a copy of the license,
+* please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+*
+* Software distributed under the Mozilla Public License is distributed on an "AS IS"
+* basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+* the license for the specific language governing your rights and limitations.
+*/
+
+package pt.webdetails.cpf;
+
+import junit.framework.Assert;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Test;
+import pt.webdetails.cpf.utils.MimeTypes;
+
+public class MimeTypeHandlerTest {
+
+  private static final String EXTENSION_ONLY_KNOW_IN_CPF = "cdfde";
+  private static final String EXPECTED_OUTCOME_IN_CPF = MimeTypes.JSON;
+
+  private static final String EXTENSION_ONLY_KNOW_IN_PLATFORM = "rtf";
+  private static final String EXPECTED_OUTCOME_IN_PLATFORM = "application/rtf";
+
+  private static final String EXTENSION_UNKNOWN_BY_ALL = "qwerty";
+  private static final String EXPECTED_OUTCOME_UNKNOWN_BY_ALL = "application/unknown";
+
+  private Log logger = LogFactory.getLog( MimeTypeHandlerTest.class );
+
+  @Test
+  public void testGetExtensionOnlyKnownInPlatform() {
+
+    String actualOutcome = StringUtils.EMPTY;
+
+    try {
+
+      actualOutcome = MimeTypeHandler.getMimeTypeFromExtension( EXTENSION_ONLY_KNOW_IN_PLATFORM );
+
+      log( "testGetExtensionOnlyKnownInPlatform()", EXTENSION_ONLY_KNOW_IN_PLATFORM, EXPECTED_OUTCOME_IN_PLATFORM,
+        actualOutcome );
+
+    } catch ( Throwable t ) {
+      logger.error( t );
+      Assert.fail();
+    }
+
+    Assert.assertTrue( EXPECTED_OUTCOME_IN_PLATFORM.equalsIgnoreCase( actualOutcome ) );
+  }
+
+  @Test
+  public void testGetExtensionOnlyKnownInCpf() {
+
+    String actualOutcome = StringUtils.EMPTY;
+
+    try {
+
+      actualOutcome = MimeTypeHandler.getMimeTypeFromExtension( EXTENSION_ONLY_KNOW_IN_CPF );
+
+      log( "testGetExtensionOnlyKnownInCpf()", EXTENSION_ONLY_KNOW_IN_CPF, EXPECTED_OUTCOME_IN_CPF, actualOutcome );
+
+    } catch ( Throwable t ) {
+      logger.error( t );
+      Assert.fail();
+    }
+
+    Assert.assertTrue( EXPECTED_OUTCOME_IN_CPF.equalsIgnoreCase( actualOutcome ) );
+  }
+
+  @Test
+  public void testGetExtensionUnknownByAll() {
+
+    String actualOutcome = StringUtils.EMPTY;
+
+    try {
+
+      actualOutcome = MimeTypeHandler.getMimeTypeFromExtension( EXTENSION_UNKNOWN_BY_ALL );
+
+      log( "testGetExtensionUnknownByAll()", EXTENSION_UNKNOWN_BY_ALL, EXPECTED_OUTCOME_UNKNOWN_BY_ALL,
+        actualOutcome );
+
+    } catch ( Throwable t ) {
+      logger.error( t );
+      Assert.fail();
+    }
+
+    Assert.assertTrue( EXPECTED_OUTCOME_UNKNOWN_BY_ALL.equalsIgnoreCase( actualOutcome ) );
+  }
+
+  private void log( String methodName, String testExtension, String expectedOutcome, String actualOutcome ) {
+    logger.info( methodName + " for '" + testExtension + "'; expected '" + expectedOutcome + "', actualOutcome was '"
+      + actualOutcome + "' => " + ( expectedOutcome.equalsIgnoreCase( actualOutcome ) ? "OK" : "FAIL" ) );
+  }
+}


### PR DESCRIPTION
...unknown Content-type in the response header

```
- [cpf-pentaho5] new MimeTypeHandler calls platform's org.pentaho.platform.util.web.MimeHelper, defaulting to cpf-core's pt.webdetails.cpf.utils.MimeTypes (if first one is not able to resolve)
- added unit tests
- added missing log4j.xml to /test-src (fixes unit test logging)
```
