### PR TITLE
[CDF-431] Centralize MessageBundlesHelper calls: move class to cpf-core

### DIFF
--- a/cpf-core/ivy.xml
+++ b/cpf-core/ivy.xml
@@ -51,6 +51,7 @@
     <dependency org="junit" name="junit" conf="test->default" rev='4.10'/>
     <dependency org="commons-httpclient" name="commons-httpclient" conf="test->default" rev='3.1'/>
     <dependency org="hsqldb" name="hsqldb" conf="test->default" rev='1.8.0.10'/>
+    <dependency org="org.mockito" name="mockito-core" rev="1.9.5" conf="test->default"/>
 
   </dependencies>
 

--- a/cpf-core/src/pt/webdetails/cpf/localization/MessageBundlesHelper.java
+++ b/cpf-core/src/pt/webdetails/cpf/localization/MessageBundlesHelper.java
@@ -1,0 +1,313 @@
+/*!
+ * Copyright 2002 - 2014 Webdetails, a Pentaho company.  All rights reserved.
+ * 
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpf.localization;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import pt.webdetails.cpf.Util;
+import pt.webdetails.cpf.repository.api.IBasicFile;
+import pt.webdetails.cpf.repository.api.IBasicFileFilter;
+import pt.webdetails.cpf.repository.api.IRWAccess;
+import pt.webdetails.cpf.repository.api.IReadAccess;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class MessageBundlesHelper {
+
+  public static final String BASE_CACHE_DIR = "tmp/.cache"; //$NON-NLS-1$
+  public static final String BASE_MESSAGES_FILENAME = "messages"; //$NON-NLS-1$
+  public static final String MESSAGES_EXTENSION = ".properties"; //$NON-NLS-1$
+
+
+  // standard procedure is to *not* save message files to cache dir *if* they already exist there;
+  // it keeps us from constantly overriding the existing ones ( and also speeds up the process );
+  // new message files will be written when user clears the cache dir folder
+  public static final boolean OVERRIDE_PROPERTIES_IN_CACHE_DIR_IF_EXIST = false; //$NON-NLS-1$
+
+
+  // the char that separates the language information from the country information:
+  // messages_<language>LOCALE_COUNTRY_SEPARATOR_CHAR<country>.properties  ( ex: messages_en-US.properties )
+  // FYI: jQuery.i18n.browserLang() returns 'en-US', 'pt-PT', .., therefore the separator char it uses is a hyphen
+  public static final String LANGUAGE_COUNTRY_SEPARATOR = "-"; //$NON-NLS-1$
+
+
+  // matches: messages_en.properties, messages_en-US.properties;
+  // does not match: messages.properties, messages_EN.properties, messages_en_us.properties
+  public final String REGEXP =
+    BASE_MESSAGES_FILENAME + "_[a-z][a-z](" + LANGUAGE_COUNTRY_SEPARATOR + "[A-Z][A-Z]){0,1}" + MESSAGES_EXTENSION;
+
+
+  private static final Log logger = LogFactory.getLog( MessageBundlesHelper.class );
+
+  Locale locale;
+  String dashboardFolderPath;
+  IReadAccess dashboardAccess;
+  IRWAccess pluginAccess;
+  String pluginStaticBaseContentUrl;
+
+  public MessageBundlesHelper( String dashboardFolderPath, IReadAccess dashboardAccess, IRWAccess pluginAccess,
+                      Locale locale, String pluginStaticBaseContentUrl ) throws IllegalArgumentException, IOException {
+
+    if ( dashboardAccess == null ) {
+      throw new IllegalArgumentException( "dashboardAccess is null" );
+
+    } else if ( pluginAccess == null ) {
+      throw new IllegalArgumentException( "pluginAccess is null" );
+
+    } else if ( locale == null || StringUtils.isEmpty( locale.getLanguage() ) ) {
+      throw new IllegalArgumentException( "locale language is null" );
+
+    } else if ( StringUtils.isEmpty( pluginStaticBaseContentUrl ) ) {
+      throw new IllegalArgumentException( "pluginStaticBaseContentUrl is null" );
+
+    }
+
+    setDashboardFolderPath( StringUtils.isEmpty( dashboardFolderPath ) ? Util.SEPARATOR : dashboardFolderPath );
+    setDashboardAccess( dashboardAccess );
+    setPluginAccess( pluginAccess );
+    setPluginStaticBaseContentUrl( pluginStaticBaseContentUrl );
+    setLocale( locale );
+
+    init();
+  }
+
+  protected void init() throws IOException {
+
+    boolean success = createCacheDirIfNotExists();
+
+    if ( success ) {
+      saveI18NMessageFilesToCacheDir();
+    }
+  }
+
+  protected boolean createCacheDirIfNotExists() {
+
+    if ( !getPluginAccess().fileExists( getBaseTempCacheFolder() ) ) {
+
+      logger.info( "Attempting to create base base cache dir at " + getBaseTempCacheFolder() );
+
+      if ( getPluginAccess().createFolder( getBaseTempCacheFolder() ) ) {
+        logger.info( "Base cache dir created successfully" );
+
+      } else {
+        logger.error( "Unable to create base cache dir at " + getBaseTempCacheFolder() );
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * This method is at the core of the MessageBundlesHelper engine.
+   * <p/>
+   * It fetches all properties files within a provided location, and stores each of them in a temp cache directory.
+   * <p/>
+   * 1rst - in the local folder ( local to the dashboard ) search for 'messages.properties'
+   * <p/>
+   * 2nd - in the same folder, search for messages_<language>.properties and
+   * messages_<language>LOCALE_COUNTRY_SEPARATOR<country>.properties;
+   */
+  protected void saveI18NMessageFilesToCacheDir() throws IOException {
+
+    // first let's check if there is a base properties file ( 'messages.properties' ) and save it to cache dir
+    saveBaseMessageToCacheDir( OVERRIDE_PROPERTIES_IN_CACHE_DIR_IF_EXIST );
+
+    // next: list all the properties files found in getDashboardFolder() that are meant to be
+    // included in the bundled up properties file within the temp cache dir
+
+    // search for messages_<language>.properties and messages_<language>_<country>.properties
+    // a dashboard may have multiple localized properties files ( messages_en.properties, messages_pt.properties, ... )
+    List<IBasicFile> localizedPropertiesFiles =
+      getDashboardAccess().listFiles( getDashboardFolderPath(), new LocalizedMessageFilter(), 1, false, true );
+
+
+    // standard procedure is to *not* save message files to cache dir *if* they already exist there;
+    // it keeps us from constantly overriding the existing ones ( and also speeds up the process );
+    // new message files will be written when user clears the cache dir folder
+    if ( !OVERRIDE_PROPERTIES_IN_CACHE_DIR_IF_EXIST ) {
+      localizedPropertiesFiles = filterOutMessagesAlreadySavedInCacheDir( localizedPropertiesFiles );
+    }
+
+    if ( localizedPropertiesFiles != null ) {
+
+      for ( IBasicFile localizedPropertyFile : localizedPropertiesFiles ) {
+
+        String fileInCacheDirPath = Util.joinPath( getBaseTempCacheFolder(), localizedPropertyFile.getName() );
+
+        try {
+
+          getPluginAccess().saveFile( fileInCacheDirPath, localizedPropertyFile.getContents() );
+
+        } catch ( IOException e ) {
+          logger.error( "Unable to save " + localizedPropertyFile.getName() + " in " + getBaseTempCacheFolder(), e );
+            /* log this as error and continue on to the next localized properties file  */
+        }
+      }
+    }
+
+
+    // all is done; now, we just need to ensure there are properties files in cache dir pertaining the specific
+    // locale the user has provided in the constructor; ideally, this should have already been taken care of
+    // in the FOR cycle above; but in the off-chance they haven't been stored in the cache dir, we'll go ahead
+    // and store them as empty files;
+    String localizedMsgPath = Util.joinPath( getBaseTempCacheFolder(),
+      ( BASE_MESSAGES_FILENAME + "_" + getLocale().getLanguage() + MESSAGES_EXTENSION ) );
+
+    String localizedCountryMsgPath = Util.joinPath( getBaseTempCacheFolder(),
+      ( BASE_MESSAGES_FILENAME + "_" + getLocale().getLanguage() + LANGUAGE_COUNTRY_SEPARATOR +
+        getLocale().getCountry() + MESSAGES_EXTENSION ) );
+
+    if ( !getPluginAccess().fileExists( localizedMsgPath ) ) {
+      getPluginAccess().saveFile( localizedMsgPath, new ByteArrayInputStream( new String().getBytes() ) );
+    }
+
+    if ( !getPluginAccess().fileExists( localizedCountryMsgPath ) ) {
+      getPluginAccess().saveFile( localizedCountryMsgPath, new ByteArrayInputStream( new String().getBytes() ) );
+    }
+  }
+
+  protected boolean saveBaseMessageToCacheDir( boolean overrideIfExists ) throws IOException {
+    String baseMsgPath = Util.joinPath( getDashboardFolderPath(), ( BASE_MESSAGES_FILENAME + MESSAGES_EXTENSION ) );
+
+    IBasicFile basePropertiesFile = null;
+
+    // first let's check if there is a base properties file ( 'messages.properties' )
+    if ( getDashboardAccess().fileExists( baseMsgPath ) ) {
+
+      basePropertiesFile = getDashboardAccess().fetchFile( baseMsgPath );
+
+      String basePropertiesCachePath =
+        Util.joinPath( getBaseTempCacheFolder(), ( BASE_MESSAGES_FILENAME + MESSAGES_EXTENSION ) );
+
+      if ( !getPluginAccess().fileExists( basePropertiesCachePath ) || overrideIfExists ) {
+          getPluginAccess().saveFile( basePropertiesCachePath, basePropertiesFile.getContents() );
+      }
+    }
+    return true;
+  }
+
+  protected List<IBasicFile> filterOutMessagesAlreadySavedInCacheDir( List<IBasicFile> localizedMessages ) {
+
+    List<IBasicFile> filteredLocalizedMessages = new ArrayList<IBasicFile>();
+
+    if ( localizedMessages != null ) {
+
+      for ( IBasicFile message : localizedMessages ) {
+
+        if ( !getPluginAccess().fileExists( Util.joinPath( getBaseTempCacheFolder(), message.getName() ) ) ) {
+
+          filteredLocalizedMessages.add( message );
+        }
+      }
+    }
+
+    return filteredLocalizedMessages;
+  }
+
+  public String getMessageFilesCacheUrl() {
+    return FilenameUtils.normalize( FilenameUtils.separatorsToUnix(
+      Util.joinPath( getPluginStaticBaseContentUrl(), BASE_CACHE_DIR, getDashboardFolderPath(), "/" ) ) );
+  }
+
+  public String replaceParameters( String text, ArrayList<String> i18nTagsList ) throws IOException {
+
+    if ( i18nTagsList == null ) {
+      i18nTagsList = new ArrayList<String>();
+    }
+
+    // ex: en-GB, en-US, pt-PT, pt-BR, fr-FR,  ..
+    String languageCode = getLocale().getLanguage() + LANGUAGE_COUNTRY_SEPARATOR + getLocale().getCountry();
+
+    text = text.replaceAll( "\\{load\\}", "onload=\"load()\"" ); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    text = text.replaceAll( "\\{body-tag-unload\\}", "" ); //$NON-NLS-1$
+    text = text.replaceAll( "#\\{GLOBAL_MESSAGE_SET_NAME\\}", BASE_MESSAGES_FILENAME ); //$NON-NLS-1$
+    text = text.replaceAll( "#\\{GLOBAL_MESSAGE_SET_PATH\\}", getMessageFilesCacheUrl() ); //$NON-NLS-1$
+    text = text.replaceAll( "#\\{GLOBAL_MESSAGE_SET\\}", buildMessageSetCode( i18nTagsList ) ); //$NON-NLS-1$
+    text = text.replaceAll( "#\\{LANGUAGE_CODE\\}", languageCode );
+    return text;
+  }
+
+  public IReadAccess getDashboardAccess() {
+    return dashboardAccess;
+  }
+
+  public void setDashboardAccess( IReadAccess dashboardAccess ) {
+    this.dashboardAccess = dashboardAccess;
+  }
+
+  public IRWAccess getPluginAccess() {
+    return pluginAccess;
+  }
+
+  public void setPluginAccess( IRWAccess pluginAccess ) {
+    this.pluginAccess = pluginAccess;
+  }
+
+  public Locale getLocale() {
+    return locale;
+  }
+
+  public void setLocale( Locale locale ) {
+    this.locale = locale;
+  }
+
+  public String getPluginStaticBaseContentUrl() {
+    return pluginStaticBaseContentUrl;
+  }
+
+  public void setPluginStaticBaseContentUrl( String pluginStaticBaseContentUrl ) {
+    this.pluginStaticBaseContentUrl = pluginStaticBaseContentUrl;
+  }
+
+  public String getDashboardFolderPath() {
+    return dashboardFolderPath;
+  }
+
+  public void setDashboardFolderPath( String dashboardFolderPath ) {
+    this.dashboardFolderPath = dashboardFolderPath;
+  }
+
+  public String getBaseTempCacheFolder() {
+    return Util.joinPath( BASE_CACHE_DIR, getDashboardFolderPath() );
+  }
+
+  private String buildMessageSetCode( ArrayList<String> tagsList ) {
+    StringBuffer messageCodeSet = new StringBuffer();
+    for ( String tag : tagsList ) {
+      messageCodeSet
+        .append( "\\$('#" ).append( updateSelectorName( tag ) ).append( "').html(jQuery.i18n.prop('" ).append( tag )
+        .append( "'));\n" ); //$NON-NLS-1$
+    }
+    return messageCodeSet.toString();
+  }
+
+  private String updateSelectorName( String name ) {
+    // If we have the char '.' in the message key substitute it conventionally to '_'
+    // when dynamically generating the selector name. The "." character is not permitted in the selector id name
+    return name.replace( ".", "_" );
+  }
+
+  class LocalizedMessageFilter implements IBasicFileFilter {
+
+    @Override
+    public boolean accept( IBasicFile file ) {
+      return file != null && !StringUtils.isEmpty( file.getName() ) && file.getName().matches( REGEXP );
+    }
+  }
+}

--- a/cpf-core/test-src/pt/webdetails/cpf/localization/MessageBundlesHelperTest.java
+++ b/cpf-core/test-src/pt/webdetails/cpf/localization/MessageBundlesHelperTest.java
@@ -1,0 +1,190 @@
+/*!
+ * Copyright 2002 - 2014 Webdetails, a Pentaho company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpf.localization;
+
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.junit.Test;
+import pt.webdetails.cpf.Util;
+import pt.webdetails.cpf.localization.test.BasicFile;
+import pt.webdetails.cpf.localization.test.PluginWriteAccess;
+import pt.webdetails.cpf.localization.test.SomeFolderReadAccess;
+import pt.webdetails.cpf.repository.api.IBasicFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class MessageBundlesHelperTest extends TestCase {
+
+  private final Locale LOCALE = new Locale( "en", "US" );
+
+  private final String MOCK_TEXT_FOR_PARAM_REPLACEMENT =
+    "#{GLOBAL_MESSAGE_SET_NAME};#{GLOBAL_MESSAGE_SET_PATH};#{LANGUAGE_CODE}";
+
+  private final String[] SOME_ACCEPTED_FILES = new String[] {
+    "messages.properties",
+    "messages_en.properties",
+    "messages_pt.properties",
+    "messages_en" + MessageBundlesHelper.LANGUAGE_COUNTRY_SEPARATOR + "US.properties",
+    "messages_pt" + MessageBundlesHelper.LANGUAGE_COUNTRY_SEPARATOR + "PT.properties"
+  };
+
+  private final String[] SOME_NON_ACCEPTED_FILES = new String[] {
+    "some-dashboard.wcdf",
+    "some-dashboard.cdfde",
+    "some-dashboard.cda",
+    "messages_with_non_matchable_regex.properties",
+    "mEssAGeS_PT_br",
+  };
+
+  private final String SOME_FOLDER_PATH = Util.SEPARATOR;
+
+  private final String MOCK_PLUGIN_URL = Util.SEPARATOR + "dummy" + Util.SEPARATOR + "url";
+
+  @Test
+  public void testAcceptedMessages() {
+
+    List<IBasicFile> basicFiles = toBasicFileList( Util.SEPARATOR, SOME_ACCEPTED_FILES );
+
+    SomeFolderReadAccess someFolderAccess = new SomeFolderReadAccess( basicFiles );
+    PluginWriteAccess pluginAccess = new PluginWriteAccess();
+
+    MessageBundlesHelper mbh = null;
+
+    try {
+      mbh = new MessageBundlesHelper( SOME_FOLDER_PATH, someFolderAccess, pluginAccess, LOCALE, MOCK_PLUGIN_URL );
+    } catch ( Exception e ) {
+      Assert.fail();
+    }
+
+    assertTrue( mbh != null );
+    assertTrue( pluginAccess != null && pluginAccess.getStoredFiles() != null );
+    assertTrue( pluginAccess.getStoredFiles().size() > 0 );
+    assertTrue( pluginAccess.getStoredFiles().size() == SOME_ACCEPTED_FILES.length );
+
+    for ( String file : SOME_ACCEPTED_FILES ) {
+
+      String messageInCacheDir = Util.joinPath( Util.SEPARATOR, MessageBundlesHelper.BASE_CACHE_DIR, file );
+      assertTrue( pluginAccess.getStoredFiles().contains( new BasicFile( messageInCacheDir ) ) );
+    }
+  }
+
+  @Test
+  public void testNonAcceptedMessages() {
+
+    List<IBasicFile> basicFiles = toBasicFileList( Util.SEPARATOR, SOME_NON_ACCEPTED_FILES );
+
+    SomeFolderReadAccess someFolderAccess = new SomeFolderReadAccess( basicFiles );
+    PluginWriteAccess pluginAccess = new PluginWriteAccess();
+
+    MessageBundlesHelper mbh = null;
+
+    try {
+      mbh = new MessageBundlesHelper( SOME_FOLDER_PATH, someFolderAccess, pluginAccess, LOCALE, MOCK_PLUGIN_URL );
+    } catch ( Exception e ) {
+      Assert.fail();
+    }
+
+    assertTrue( mbh != null );
+    assertTrue( pluginAccess != null && pluginAccess.getStoredFiles() != null );
+    assertTrue( pluginAccess.getStoredFiles().size() > 0 );
+
+    // 2 empty files created ( as a fallback ) and regarding the provided LOCALE: 'messages_en.properties'
+    // and 'messages_en-US.properties'
+    assertTrue( pluginAccess.getStoredFiles().size() == 2 );
+
+    String fallback_file_en = "messages_" + LOCALE.getLanguage() + ".properties";
+    String fallback_file_en_messageInCacheDir = Util.joinPath( Util.SEPARATOR, MessageBundlesHelper.BASE_CACHE_DIR,
+      fallback_file_en );
+
+    String fallback_file_en_US =
+      "messages_" + LOCALE.getLanguage() + MessageBundlesHelper.LANGUAGE_COUNTRY_SEPARATOR + LOCALE.getCountry()
+        + ".properties";
+
+    String fallback_file_en_US_messageInCacheDir = Util.joinPath( Util.SEPARATOR, MessageBundlesHelper.BASE_CACHE_DIR,
+      fallback_file_en_US );
+
+    assertTrue( pluginAccess.getStoredFiles().contains( new BasicFile( fallback_file_en_messageInCacheDir ) ) );
+    assertTrue( pluginAccess.getStoredFiles().contains( new BasicFile( fallback_file_en_US_messageInCacheDir ) ) );
+
+    // check if none of the following files has been stored in cache dir
+    for ( String file : SOME_NON_ACCEPTED_FILES ) {
+
+      String messageInCacheDir = Util.joinPath( Util.SEPARATOR, MessageBundlesHelper.BASE_CACHE_DIR, file );
+      assertFalse( pluginAccess.getStoredFiles().contains( new BasicFile( messageInCacheDir ) ) );
+    }
+  }
+
+  @Test
+  public void testTextReplacement() {
+
+    List<IBasicFile> basicFiles = toBasicFileList( Util.SEPARATOR, SOME_ACCEPTED_FILES );
+
+    SomeFolderReadAccess someFolderAccess = new SomeFolderReadAccess( basicFiles );
+    PluginWriteAccess pluginAccess = new PluginWriteAccess();
+
+    MessageBundlesHelper mbh = null;
+
+    try {
+      mbh = new MessageBundlesHelper( SOME_FOLDER_PATH, someFolderAccess, pluginAccess, LOCALE, MOCK_PLUGIN_URL );
+    } catch ( Exception e ) {
+      Assert.fail();
+    }
+
+    assertTrue( mbh != null && pluginAccess != null && pluginAccess.getStoredFiles() != null );
+    assertTrue( pluginAccess.getStoredFiles().size() == SOME_ACCEPTED_FILES.length );
+
+    String i18nReplacedText = null;
+
+    try {
+      i18nReplacedText = mbh.replaceParameters( MOCK_TEXT_FOR_PARAM_REPLACEMENT, null );
+    } catch ( Exception e ) {
+      Assert.fail();
+    }
+
+    assertNotNull( i18nReplacedText );
+
+    String[] replacedText = i18nReplacedText.split( ";" );
+
+    assertTrue( replacedText.length == 3 );
+    assertTrue( replacedText[ 0 ].equals( MessageBundlesHelper.BASE_MESSAGES_FILENAME ) );
+    assertTrue( replacedText[ 1 ]
+      .equals( Util.joinPath( MOCK_PLUGIN_URL, MessageBundlesHelper.BASE_CACHE_DIR, SOME_FOLDER_PATH ) ) );
+    assertTrue( replacedText[ 2 ]
+      .equals( LOCALE.getLanguage() + MessageBundlesHelper.LANGUAGE_COUNTRY_SEPARATOR + LOCALE.getCountry() ) );
+  }
+
+  private List<IBasicFile> toBasicFileList( String path, String[] filesNames ) {
+
+    List<IBasicFile> basicFiles = new ArrayList<IBasicFile>();
+
+    if ( filesNames != null ) {
+
+      for ( String fileName : filesNames ) {
+
+        if ( path != null && fileName != null ) {
+
+          IBasicFile file = new BasicFile( path + fileName );
+
+          if ( !basicFiles.contains( file ) ) {
+            basicFiles.add( file );
+          }
+        }
+      }
+    }
+
+    return basicFiles;
+  }
+}

--- a/cpf-core/test-src/pt/webdetails/cpf/localization/test/BasicFile.java
+++ b/cpf-core/test-src/pt/webdetails/cpf/localization/test/BasicFile.java
@@ -1,0 +1,57 @@
+/*!
+ * Copyright 2002 - 2014 Webdetails, a Pentaho company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpf.localization.test;
+
+import pt.webdetails.cpf.Util;
+import pt.webdetails.cpf.repository.api.IBasicFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class BasicFile implements IBasicFile {
+
+  private String path;
+
+  public BasicFile( String path ) {
+    this.path = path;
+  }
+
+  @Override public InputStream getContents() throws IOException {
+    return new ByteArrayInputStream( path.getBytes() );
+  }
+
+  @Override public String getName() {
+    return path.substring( path.lastIndexOf( Util.SEPARATOR ) + 1 );
+  }
+
+  @Override public String getFullPath() {
+    return path;
+  }
+
+  @Override public String getPath() {
+    return path;
+  }
+
+  @Override public String getExtension() {
+    return path.substring( path.lastIndexOf( '.' ) + 1 );
+  }
+
+  @Override public boolean isDirectory() {
+    return false;
+  }
+
+  @Override public boolean equals( Object o ) {
+    return ( o != null && o instanceof BasicFile ) ? this.getPath().equals( ( (BasicFile) o ).getPath() ) : false;
+  }
+}

--- a/cpf-core/test-src/pt/webdetails/cpf/localization/test/PluginWriteAccess.java
+++ b/cpf-core/test-src/pt/webdetails/cpf/localization/test/PluginWriteAccess.java
@@ -1,0 +1,89 @@
+/*!
+ * Copyright 2002 - 2014 Webdetails, a Pentaho company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpf.localization.test;
+
+import pt.webdetails.cpf.repository.api.IBasicFile;
+import pt.webdetails.cpf.repository.api.IBasicFileFilter;
+import pt.webdetails.cpf.repository.api.IRWAccess;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PluginWriteAccess implements IRWAccess {
+
+  private List<IBasicFile> storedFiles = new ArrayList<IBasicFile>();
+
+  public List<IBasicFile> getStoredFiles(){
+    return storedFiles;
+  }
+
+  @Override public boolean saveFile( String path, InputStream contents ) {
+    return storedFiles.add( new BasicFile( path ) );
+  }
+
+  @Override public boolean copyFile( String pathFrom, String pathTo ) {
+    return true;
+  }
+
+  @Override public boolean deleteFile( String path ) {
+    return fileExists( path ) ? storedFiles.remove( fetchFile( path ) ) : false;
+  }
+
+  @Override public boolean createFolder( String path ) {
+    return true;
+  }
+
+  @Override public InputStream getFileInputStream( String path ) throws IOException {
+    return fileExists( path ) ? fetchFile( path ).getContents() : null;
+  }
+
+  @Override public boolean fileExists( String path ) {
+    return storedFiles != null && storedFiles.contains( new BasicFile( path ) );
+  }
+
+  @Override public long getLastModified( String path ) {
+    return 0;
+  }
+
+  @Override public List<IBasicFile> listFiles( String path, IBasicFileFilter filter, int maxDepth, boolean includeDirs,
+                                               boolean showHiddenFilesAndFolders ) {
+    List<IBasicFile> filteredFiles = new ArrayList<IBasicFile>();
+
+    for ( IBasicFile file : storedFiles ) {
+
+      if ( filter != null && filter.accept( file ) ) {
+        filteredFiles.add( file );
+      }
+    }
+    return filteredFiles;
+  }
+
+  @Override public List<IBasicFile> listFiles( String path, IBasicFileFilter filter, int maxDepth,
+                                               boolean includeDirs ) {
+    return listFiles( path, filter, maxDepth, includeDirs, true );
+  }
+
+  @Override public List<IBasicFile> listFiles( String path, IBasicFileFilter filter, int maxDepth ) {
+    return listFiles( path, filter, maxDepth, true, true );
+  }
+
+  @Override public List<IBasicFile> listFiles( String path, IBasicFileFilter filter ) {
+    return listFiles( path, filter, -1, true, true );
+  }
+
+  @Override public IBasicFile fetchFile( String path ) {
+    return fileExists( path ) ? storedFiles.get( storedFiles.indexOf( new BasicFile( path ) ) ) : null;
+  }
+}

--- a/cpf-core/test-src/pt/webdetails/cpf/localization/test/SomeFolderReadAccess.java
+++ b/cpf-core/test-src/pt/webdetails/cpf/localization/test/SomeFolderReadAccess.java
@@ -1,0 +1,78 @@
+/*!
+ * Copyright 2002 - 2014 Webdetails, a Pentaho company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpf.localization.test;
+
+import pt.webdetails.cpf.repository.api.IBasicFile;
+import pt.webdetails.cpf.repository.api.IBasicFileFilter;
+import pt.webdetails.cpf.repository.api.IReadAccess;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SomeFolderReadAccess implements IReadAccess {
+
+  private List<IBasicFile> files = new ArrayList<IBasicFile>();
+
+  public SomeFolderReadAccess( List<IBasicFile> files ){
+    this.files = files;
+  }
+
+  public List<IBasicFile> getFiles(){
+    return files;
+  }
+
+  @Override public InputStream getFileInputStream( String path ) throws IOException {
+    return fileExists( path ) ? fetchFile( path ).getContents() : null;
+  }
+
+  @Override public boolean fileExists( String path ) {
+    return files != null && files.contains( new BasicFile( path ) );
+  }
+
+  @Override public long getLastModified( String path ) {
+    return 0;
+  }
+
+  @Override public List<IBasicFile> listFiles( String path, IBasicFileFilter filter, int maxDepth, boolean includeDirs,
+                                               boolean showHiddenFilesAndFolders ) {
+
+    List<IBasicFile> filteredFiles = new ArrayList<IBasicFile>();
+
+    for ( IBasicFile file : files ) {
+
+      if ( filter != null && filter.accept( file ) ) {
+        filteredFiles.add( file );
+      }
+    }
+    return filteredFiles;
+  }
+
+  @Override public List<IBasicFile> listFiles( String path, IBasicFileFilter filter, int maxDepth,
+                                               boolean includeDirs ) {
+    return listFiles( path, filter, maxDepth, includeDirs, true );
+  }
+
+  @Override public List<IBasicFile> listFiles( String path, IBasicFileFilter filter, int maxDepth ) {
+    return listFiles( path, filter, maxDepth, true, true );
+  }
+
+  @Override public List<IBasicFile> listFiles( String path, IBasicFileFilter filter ) {
+    return listFiles( path, filter, -1, true, true );
+  }
+
+  @Override public IBasicFile fetchFile( String path ) {
+    return fileExists( path ) ? files.get( files.indexOf( new BasicFile( path ) ) ) : null;
+  }
+}


### PR DESCRIPTION
```
- created a MessageBundleHelper class in cpf-core
- created some unit tests for all its functionalities
-  this will have zero impact on the current code, as this is simply the creation of the class; on the next phase, we will be having CDF and CDE refer to this one for all i18n operations
```
