### PR TITLE
[CDF-431] Centralize MessageBundlesHelper calls: move class to cpf-core

### DIFF
--- a/cpf-core/src/pt/webdetails/cpf/localization/MessageBundlesHelper.java
+++ b/cpf-core/src/pt/webdetails/cpf/localization/MessageBundlesHelper.java
@@ -229,8 +229,8 @@ public class MessageBundlesHelper {
   }
 
   public String getMessageFilesCacheUrl() {
-    return FilenameUtils.normalize( FilenameUtils.separatorsToUnix(
-      Util.joinPath( getPluginStaticBaseContentUrl(), BASE_CACHE_DIR, getDashboardFolderPath(), "/" ) ) );
+    return FilenameUtils.separatorsToUnix( FilenameUtils.normalize(
+      Util.joinPath( getPluginStaticBaseContentUrl(), BASE_CACHE_DIR, getDashboardFolderPath(), Util.SEPARATOR ) ) );
   }
 
   public String replaceParameters( String text, ArrayList<String> i18nTagsList ) throws IOException {


### PR DESCRIPTION
```
- in Windows, CDF messages.properties url paths were incorrect, because FilenameUtils.normalize() ends up changing the path separator back to back-slash
- so, switched order from FilenameUtils.normalize( FilenameUtils.separatorsToUnix() ) to FilenameUtils.separatorsToUnix( FilenameUtils.normalize() )
```
