### PR TITLE
[CDA-154] Promote CoreBeanFactory to CPF

### DIFF
--- a/cpf-core/ivy.xml
+++ b/cpf-core/ivy.xml
@@ -43,6 +43,7 @@
     <dependency org="org.mozilla" name="rhino" rev="1.7R4"/>
     <!--TODO: some sanity in spring versions? -->
     <dependency org="org.springframework" name="spring-beans" rev="3.0.3.RELEASE"/>
+    <dependency org="org.springframework" name="spring-context" rev="3.0.3.RELEASE" transitive="false"/>
     <dependency org="org.springframework" name="spring-core" rev="2.5.6"/>
     <dependency org="org.springframework.security" name="spring-security-core" rev="2.0.5.RELEASE"/>
 
@@ -52,6 +53,12 @@
     <dependency org="commons-httpclient" name="commons-httpclient" conf="test->default" rev='3.1'/>
     <dependency org="org.hsqldb" name="hsqldb" conf="test->default" rev='2.3.2'/>
     <dependency org="org.mockito" name="mockito-core" rev="1.9.5" conf="test->default"/>
+
+    <dependency org="org.springframework" name="spring-beans" rev="3.0.3.RELEASE" conf="test->default"/>
+    <dependency org="org.springframework" name="spring-expression" rev="3.0.3.RELEASE" conf="test->default" transitive="false"/>
+    <dependency org="org.springframework" name="spring-context" rev="3.0.3.RELEASE" transitive="false" conf="test->default"/>
+    <dependency org="org.springframework" name="spring-core" rev="2.5.6" conf="test->default"/>
+    <dependency org="org.springframework.security" name="spring-security-core" rev="2.0.5.RELEASE" conf="test->default"/>
 
   </dependencies>
 

--- a/cpf-core/src/pt/webdetails/cpf/bean/AbstractBeanFactory.java
+++ b/cpf-core/src/pt/webdetails/cpf/bean/AbstractBeanFactory.java
@@ -1,0 +1,106 @@
+/*!
+* Copyright 2002 - 2015 Webdetails, a Pentaho company.  All rights reserved.
+*
+* This software was developed by Webdetails and is provided under the terms
+* of the Mozilla Public License, Version 2.0, or any later version. You may not use
+* this file except in compliance with the license. If you need a copy of the license,
+* please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+*
+* Software distributed under the Mozilla Public License is distributed on an "AS IS"
+* basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+* the license for the specific language governing your rights and limitations.
+*/
+package pt.webdetails.cpf.bean;
+
+import java.net.URL;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import pt.webdetails.cpf.bean.IBeanFactory;
+
+import java.net.URL;
+
+public abstract class AbstractBeanFactory implements IBeanFactory {
+
+  private static final Log logger = LogFactory.getLog( IBeanFactory.class );
+
+  protected static ConfigurableApplicationContext ctx;
+
+  public abstract String getSpringXMLFilename();
+
+  @Override
+  public Object getBean( String id ) {
+    return ( getCtx() != null && getCtx().containsBean( id ) ) ? getCtx().getBean( id ) : null;
+  }
+
+  @Override
+  public boolean containsBean( String id ) {
+    return getCtx() != null ? getCtx().containsBean( id ) : false;
+  }
+
+  @Override
+  public String[] getBeanNamesForType( Class<?> clazz ) {
+    return getCtx().getBeanNamesForType( clazz );
+  }
+
+  protected ConfigurableApplicationContext getCtx(){
+    if( ctx == null ){
+      ctx = getSpringBeanFactory( getSpringXMLFilename() );
+    }
+
+    return ctx;
+  }
+
+  protected ConfigurableApplicationContext getSpringBeanFactory( String config ) {
+    getLogger().debug( "bean factory init" );
+
+    try {
+      // important: use the plugin's classloader
+      final ClassLoader cl = getClass().getClassLoader();
+
+      URL url = cl.getResource( config );
+      if ( url != null ) {
+        getLogger().debug( "Found spring file @ " + url );
+
+        ConfigurableApplicationContext context = new ClassPathXmlApplicationContext( config ) {
+
+          @Override
+          protected void initBeanDefinitionReader( XmlBeanDefinitionReader beanDefinitionReader) {
+            beanDefinitionReader.setBeanClassLoader(cl);
+          }
+
+          @Override
+          protected void prepareBeanFactory( ConfigurableListableBeanFactory clBeanFactory ) {
+            super.prepareBeanFactory(clBeanFactory);
+            clBeanFactory.setBeanClassLoader(cl);
+          }
+
+          /**
+           * Critically important to override this and return the desired classloader
+           **/
+          @Override
+          public ClassLoader getClassLoader() {
+            return cl;
+          }
+        };
+        getLogger().debug( "bean factory context" );
+        return context;
+      }
+    } catch (Exception e) {
+      getLogger().fatal( "Error loading " + config, e );
+    }
+    getLogger().fatal( "Spring definition file does not exist. "
+        + "There should be a " + config + " file on the classpath ");
+    return null;
+
+  }
+
+  protected Log getLogger(){
+    return logger;
+  }
+}

--- a/cpf-core/src/pt/webdetails/cpf/bean/IBeanFactory.java
+++ b/cpf-core/src/pt/webdetails/cpf/bean/IBeanFactory.java
@@ -1,0 +1,25 @@
+/*!
+* Copyright 2002 - 2015 Webdetails, a Pentaho company.  All rights reserved.
+*
+* This software was developed by Webdetails and is provided under the terms
+* of the Mozilla Public License, Version 2.0, or any later version. You may not use
+* this file except in compliance with the license. If you need a copy of the license,
+* please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+*
+* Software distributed under the Mozilla Public License is distributed on an "AS IS"
+* basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+* the license for the specific language governing your rights and limitations.
+*/
+package pt.webdetails.cpf.bean;
+
+public interface IBeanFactory {
+
+  String getSpringXMLFilename();
+
+  Object getBean( String id );
+
+  boolean containsBean( String id );
+
+  String[] getBeanNamesForType( Class<?> clazz );
+
+}

--- a/cpf-core/test-src/pt/webdetails/cpf/bean/BeanFactoryTest.java
+++ b/cpf-core/test-src/pt/webdetails/cpf/bean/BeanFactoryTest.java
@@ -1,0 +1,83 @@
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpf.bean;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import pt.webdetails.cpf.bean.IDummyBean;
+
+public class BeanFactoryTest extends TestCase {
+
+  /*
+   * We tend to use BeanFactory class to load spring xml files that are
+   * in the classloader's base path.
+   *
+   * But in unit testing, things differ: the test class
+   * is in a /test-src dir, but it gets copied into /bin/test/classes
+   *
+   * So we count from that base dir onwards
+   */
+
+  private final String SPRING_XML_FILE = "./pt/webdetails/cpf/bean/test.spring.xml";
+
+  IDummyBean dummyBean;
+  IBeanFactory factory;
+
+  @Before
+  public void setUp() {
+
+    factory = new AbstractBeanFactory() {
+      @Override public String getSpringXMLFilename() { return SPRING_XML_FILE; }
+    };
+  }
+
+  @Test
+  public void testSpringXmlFileFound() {
+
+    assertNotNull( factory );
+
+    assertFalse( factory.containsBean( "IBogusBean" ) );
+
+    assertTrue( factory.containsBean( IDummyBean.class.getSimpleName() ) );
+
+  }
+
+  @Test
+  public void testBeanLoadingOK() {
+
+    assertNotNull( factory );
+
+    try {
+
+      dummyBean = ( IDummyBean ) factory.getBean( IDummyBean.class.getSimpleName() );
+
+    } catch( Throwable t ) {
+      Assert.fail();
+    }
+
+    assertNotNull( dummyBean );
+
+    assertTrue( dummyBean.isBeanOK() );
+  }
+
+  @After
+  public void tearDown(){
+
+    factory = null;
+    dummyBean = null;
+  }
+}

--- a/cpf-core/test-src/pt/webdetails/cpf/bean/DummyBean.java
+++ b/cpf-core/test-src/pt/webdetails/cpf/bean/DummyBean.java
@@ -1,0 +1,26 @@
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpf.bean;
+
+public class DummyBean implements IDummyBean {
+
+  private boolean beanOK = false;
+
+  public DummyBean(){
+    beanOK = true;
+  }
+
+  public boolean isBeanOK(){
+    return beanOK;
+  }
+}

--- a/cpf-core/test-src/pt/webdetails/cpf/bean/IDummyBean.java
+++ b/cpf-core/test-src/pt/webdetails/cpf/bean/IDummyBean.java
@@ -1,0 +1,20 @@
+/*!
+ * Copyright 2002 - 2015 Webdetails, a Pentaho company.  All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to  http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or  implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpf.bean;
+
+import java.io.Serializable;
+
+public interface IDummyBean {
+	
+  boolean isBeanOK();
+}

--- a/cpf-core/test-src/pt/webdetails/cpf/bean/test.spring.xml
+++ b/cpf-core/test-src/pt/webdetails/cpf/bean/test.spring.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ws="http://jax-ws.dev.java.net/spring/core"
+	xmlns:wss="http://jax-ws.dev.java.net/spring/servlet"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
+http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd
+http://jax-ws.dev.java.net/spring/core http://jax-ws.dev.java.net/spring/core.xsd
+http://jax-ws.dev.java.net/spring/servlet http://jax-ws.dev.java.net/spring/servlet.xsd">
+
+  <context:annotation-config />
+
+  <bean id="IDummyBean" class="pt.webdetails.cpf.bean.DummyBean" />
+
+</beans>


### PR DESCRIPTION
	- moving CoreBeanFactory and spring dependencies to cpf-core
	- CoreBeanFactory was made abstract; other plugins will simply need to implement abstract method getSpringXMLFilename()
	- other plugins will stop using their own CoreBeanFactory and leverage on this one
	- other plugins' dependency footprint will be reduced, as many will no longer need to include spring.framework