### PR TITLE
[BACKLOG-22035] - Remove from feature dependencies being imported from non OSGi worl

### DIFF
--- a/assemblies/cpf-pdi/pom.xml
+++ b/assemblies/cpf-pdi/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.pentaho.ctools</groupId>
+    <artifactId>cpf-plugin-assemblies</artifactId>
+    <version>8.1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>pentaho-cpf-pdi</artifactId>
+  <packaging>feature</packaging>
+  <description>Pentaho Community Plugin Framework plugin for PDI</description>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- All of these dependencies are being provided in PDI via karaf/etc/custom.properties.
+           This is not the best way to provide them in an OSGi context and this should be revisited at some point
+           in time (i.e. remove them from custom.properties and remove them as provided from this dependency management).
+      -->
+      <dependency>
+        <groupId>dom4j</groupId>
+        <artifactId>dom4j</artifactId>
+        <version>${dom4j.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>${commons-logging.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>commons-vfs</groupId>
+        <artifactId>commons-vfs</artifactId>
+        <version>${commons-vfs.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>${servlet-api.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <!-- END provided dependencies vai custom.properties -->
+
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>cpf-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho.ctools</groupId>
+      <artifactId>cpf-osgi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/assemblies/cpf-pdi/pom.xml
+++ b/assemblies/cpf-pdi/pom.xml
@@ -45,7 +45,7 @@
         <version>${servlet-api.version}</version>
         <scope>provided</scope>
       </dependency>
-      <!-- END provided dependencies vai custom.properties -->
+      <!-- END provided dependencies via custom.properties -->
 
     </dependencies>
   </dependencyManagement>

--- a/assemblies/cpf-pdi/src/main/feature/feature.xml
+++ b/assemblies/cpf-pdi/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<features name="${project.artifactId}-repo" xmlns="http://karaf.apache.org/xmlns/features/v1.2.1">
+
+  <feature name="${project.artifactId}" version="${project.version}">
+
+    <details>${project.description}</details>
+
+  </feature>
+
+</features>

--- a/assemblies/cpf/pom.xml
+++ b/assemblies/cpf/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>pentaho-cpf</artifactId>
   <packaging>feature</packaging>
-  <description>Pentaho Community Plugin Framework plugin for PDI</description>
+  <description>Pentaho Community Plugin Framework plugin</description>
 
   <dependencies>
     <dependency>

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -15,6 +15,7 @@
 
   <modules>
     <module>cpf</module>
+    <module>cpf-pdi</module>
   </modules>
 
 </project>


### PR DESCRIPTION
Marked as provided the dependencies for packages being made available via karaf/etc/custom.properties

@webdetails/millenniumfalcon @afrjorge  please review