### PR TITLE
BACKLOG-23575 - changed log level from error to debug.This is necessa…

### DIFF
--- a/pentaho/src/main/java/pt/webdetails/cpf/InterPluginCall.java
+++ b/pentaho/src/main/java/pt/webdetails/cpf/InterPluginCall.java
@@ -186,16 +186,16 @@ public class InterPluginCall implements Runnable, Callable<String>, IPluginCall 
 
     if ( beanFactory == null ) {
       if ( pluginManager.getClassLoader( pluginName ) == null ) {
-        logger.error( "No such plugin: " + pluginName );
+        logger.debug( "No such plugin: " + pluginName );
       } else {
-        logger.error( "No bean factory for plugin: " + pluginName );
+        logger.debug( "No bean factory for plugin: " + pluginName );
       }
 
       return null;
     }
 
     if ( !beanFactory.containsBean( service ) ) {
-      logger.error( "'" + service + "' bean not found in " + pluginName );
+      logger.debug( "'" + service + "' bean not found in " + pluginName );
 
       return null;
     }


### PR DESCRIPTION
…ry because in this execution path the error is verified on InterPluginBroker.run(...), so when execution returns there the error is logged, no need to log errors on a downstream execution.

InterPluginBroker.run(...) -> InterPluginBroker.getCdeRenderer() -> IPluginCall.exists() -> InterPluginCall.getBeanObject()

@webdetails/millenniumfalcon please review