### PR TITLE
[BACKLOG-24896] Refactor CPF / reimplement RCA

### DIFF
--- a/core/src/main/java/pt/webdetails/cpf/repository/api/IRepositoryAccessFactory.java
+++ b/core/src/main/java/pt/webdetails/cpf/repository/api/IRepositoryAccessFactory.java
@@ -1,0 +1,42 @@
+/*!
+ * Copyright 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
+package pt.webdetails.cpf.repository.api;
+
+import pt.webdetails.cpf.api.IUserContentAccessExtended;
+
+/**
+ * Minimal repository access provider for repository plugin needs.
+ */
+public interface IRepositoryAccessFactory {
+  /**
+   * @param basePath (optional) all subsequent paths will be relative to this
+   * @return {@link IUserContentAccessExtended} for user repository access
+   */
+  IUserContentAccessExtended getUserContentAccess( String basePath );
+
+  /**
+   * @param pluginRepositoryDir plugin path to plugin's folder
+   * @param basePath (optional) base path relative to plugin's folder. all subsequent paths will be relative to it
+   * @return {@link IReadAccess} for files in plugin's own folder
+   */
+  IReadAccess getPluginRepositoryReader( String pluginRepositoryDir, String basePath );
+
+  /**
+   * @param pluginRepositoryDir plugin path to plugin's folder
+   * @param basePath (optional) base path relative to plugin's folder. all subsequent paths will be relative to it
+   * @return {@link IRWAccess} for files in plugin's own folder
+   */
+  IRWAccess getPluginRepositoryWriter( String pluginRepositoryDir, String basePath );
+
+}

--- a/pentaho-rca/pom.xml
+++ b/pentaho-rca/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>pentaho</groupId>
+    <artifactId>cpf-plugin</artifactId>
+    <version>9.0.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>cpf-pentaho-rca</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>cpf-pentaho</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.pentaho.ctools</groupId>
+      <artifactId>cpf-rca</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>pentaho</groupId>
+      <artifactId>cpf-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/pentaho-rca/pom.xml
+++ b/pentaho-rca/pom.xml
@@ -16,14 +16,53 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.pentaho.ctools</groupId>
-      <artifactId>cpf-rca</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>pentaho</groupId>
       <artifactId>cpf-core</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>jsr311-api</artifactId>
+      <version>${jsr311-api.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.jersey.contribs</groupId>
+      <artifactId>jersey-multipart</artifactId>
+      <version>${jersey.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-core</artifactId>
+      <version>${jersey.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.jersey.contribs</groupId>
+      <artifactId>jersey-apache-client</artifactId>
+      <version>${jersey.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/pentaho-rca/src/main/java/pt/webdetails/cpf/RemotePentahoPluginEnvironment.java
+++ b/pentaho-rca/src/main/java/pt/webdetails/cpf/RemotePentahoPluginEnvironment.java
@@ -1,0 +1,50 @@
+/*!
+ * Copyright 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
+package pt.webdetails.cpf;
+
+
+import org.pentaho.ctools.cpf.repository.rca.RemoteReadAccess;
+import org.pentaho.ctools.cpf.repository.rca.RemoteReadWriteAccess;
+import org.pentaho.ctools.cpf.repository.rca.RemoteUserContentAccess;
+import pt.webdetails.cpf.api.IUserContentAccessExtended;
+import pt.webdetails.cpf.repository.api.IRWAccess;
+import pt.webdetails.cpf.repository.api.IReadAccess;
+import pt.webdetails.cpf.repository.api.IRepositoryAccessFactory;
+import pt.webdetails.cpf.repository.util.RepositoryHelper;
+
+public class RemotePentahoPluginEnvironment implements IRepositoryAccessFactory {
+
+  private final String USERNAME = System.getProperty( "repos.user" );
+  private final String PASSWORD = System.getProperty( "repos.password" );
+  private final String URI = System.getProperty( "repos.url" );
+
+  @Override
+  public IUserContentAccessExtended getUserContentAccess( String basePath ) {
+    return new RemoteUserContentAccess( basePath, URI, USERNAME, PASSWORD );
+  }
+
+  @Override
+  public IReadAccess getPluginRepositoryReader( String pluginRepositoryDir, String basePath ) {
+    basePath = RepositoryHelper.appendPath( pluginRepositoryDir, basePath );
+    return new RemoteReadAccess( basePath, URI, USERNAME, PASSWORD );
+  }
+
+  @Override
+  public IRWAccess getPluginRepositoryWriter( String pluginRepositoryDir, String basePath ) {
+    basePath = RepositoryHelper.appendPath( pluginRepositoryDir, basePath );
+    return new RemoteReadWriteAccess( basePath, URI, USERNAME, PASSWORD );
+  }
+
+
+}

--- a/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteBasicFile.java
+++ b/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteBasicFile.java
@@ -15,6 +15,7 @@ package pt.webdetails.cpf.repository.rca;
 import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileDto;
 import pt.webdetails.cpf.repository.api.IBasicFile;
 import pt.webdetails.cpf.repository.api.IReadAccess;
+import pt.webdetails.cpf.repository.util.RepositoryHelper;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,15 +28,17 @@ import java.io.InputStream;
 public class RemoteBasicFile implements IBasicFile {
   IReadAccess remote;
   RepositoryFileDto repositoryFile;
+  String relativePath;
 
-  public RemoteBasicFile(IReadAccess remote, RepositoryFileDto dto ) {
+  public RemoteBasicFile( String basePath, IReadAccess remote, RepositoryFileDto dto ) {
     this.remote = remote;
     repositoryFile = dto;
+    relativePath = RepositoryHelper.relativizePath( basePath, repositoryFile.getPath(), true );
   }
 
   @Override
   public InputStream getContents() throws IOException {
-    return remote.getFileInputStream( repositoryFile.getPath() );
+    return remote.getFileInputStream( getPath() );
   }
 
   @Override
@@ -45,12 +48,12 @@ public class RemoteBasicFile implements IBasicFile {
 
   @Override
   public String getFullPath() {
-    return repositoryFile.getPath(); // TODO: validate, do we need to append some basePath from UserContentAccess?
+    return repositoryFile.getPath();
   }
 
   @Override
   public String getPath() {
-    return repositoryFile.getPath();
+    return relativePath;
   }
 
   @Override

--- a/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteBasicFile.java
+++ b/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteBasicFile.java
@@ -1,0 +1,73 @@
+/*!
+ * Copyright 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpf.repository.rca;
+
+import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileDto;
+import pt.webdetails.cpf.repository.api.IBasicFile;
+import pt.webdetails.cpf.repository.api.IReadAccess;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Class {@code RemoteBasicFile} implements the {@code IBasicFile} interface for a remote repository file.
+ *
+ * @see IBasicFile
+ */
+public class RemoteBasicFile implements IBasicFile {
+  IReadAccess remote;
+  RepositoryFileDto repositoryFile;
+
+  public RemoteBasicFile(IReadAccess remote, RepositoryFileDto dto ) {
+    this.remote = remote;
+    repositoryFile = dto;
+  }
+
+  @Override
+  public InputStream getContents() throws IOException {
+    return remote.getFileInputStream( repositoryFile.getPath() );
+  }
+
+  @Override
+  public String getName() {
+    return repositoryFile.getName();
+  }
+
+  @Override
+  public String getFullPath() {
+    return repositoryFile.getPath(); // TODO: validate, do we need to append some basePath from UserContentAccess?
+  }
+
+  @Override
+  public String getPath() {
+    return repositoryFile.getPath();
+  }
+
+  @Override
+  public String getExtension() {
+    final String path = repositoryFile.getPath();
+    if ( path.length() == 0 ) {
+      return path;
+    }
+    final int index = path.lastIndexOf( "." );
+    if ( index == -1 ) {
+      return "";
+    }
+    return path.substring( index + 1 );
+  }
+
+  @Override
+  public boolean isDirectory() {
+    return repositoryFile.isFolder();
+  }
+}

--- a/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteBasicFile.java
+++ b/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteBasicFile.java
@@ -63,7 +63,7 @@ public class RemoteBasicFile implements IBasicFile {
       return path;
     }
     final int index = path.lastIndexOf( "." );
-    if ( index == -1 ) {
+    if ( index <= 0 ) {
       return "";
     }
     return path.substring( index + 1 );

--- a/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteReadAccess.java
+++ b/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteReadAccess.java
@@ -84,11 +84,11 @@ public class RemoteReadAccess implements IReadAccess {
     String fullPath = buildPath( path );
     String requestURL = createRequestURL( fullPath, "properties" );
 
-    RepositoryFileDto response = client.resource( requestURL )
+    ClientResponse clientResponse = client.resource( requestURL )
       .type( MediaType.APPLICATION_XML )
-      .get( RepositoryFileDto.class );
+      .get( ClientResponse.class );
 
-    return response != null;
+    return ( clientResponse != null && clientResponse.getStatus() == ClientResponse.Status.OK.getStatusCode() );
   }
 
   @Override
@@ -138,7 +138,7 @@ public class RemoteReadAccess implements IReadAccess {
       return null;
     }
 
-    return treeFlatten( response, includeDirs, filter, path );
+    return treeFlatten( response, includeDirs, filter, fullPath );
   }
 
   @Override
@@ -163,7 +163,7 @@ public class RemoteReadAccess implements IReadAccess {
     RepositoryFileDto response = client.resource( requestURL )
       .type( MediaType.APPLICATION_XML )
       .get( RepositoryFileDto.class );
-    return new RemoteBasicFile( this, response );
+    return new RemoteBasicFile( basePath, this, response );
   }
 
   static String encodePath( String path ) {
@@ -192,7 +192,7 @@ public class RemoteReadAccess implements IReadAccess {
   }
 
   private void treeFlattenRecursive(RepositoryFileTreeDto node, boolean includeDirs, IBasicFileFilter filter, List<IBasicFile> result, String queryPath ) {
-    IBasicFile file = new RemoteBasicFile( this, node.getFile() );
+    IBasicFile file = new RemoteBasicFile( basePath, this, node.getFile() );
 
     if ( ( includeDirs || !file.isDirectory() ) && !pathEquals( file.getFullPath(), queryPath ) && ( filter == null || filter.accept( file ) ) ) {
       result.add( file );

--- a/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteReadAccess.java
+++ b/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteReadAccess.java
@@ -1,0 +1,226 @@
+/*!
+ * Copyright 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+package pt.webdetails.cpf.repository.rca;
+
+import com.sun.jersey.api.json.JSONConfiguration;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileDto;
+import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileTreeDto;
+import pt.webdetails.cpf.repository.api.IBasicFile;
+import pt.webdetails.cpf.repository.api.IBasicFileFilter;
+import pt.webdetails.cpf.repository.api.IReadAccess;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.api.client.config.ClientConfig;
+import com.sun.jersey.api.client.config.DefaultClientConfig;
+import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter;
+
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Class {@code RemoteReadAccess} provides an implementation of {@code IReadAccess} via REST calls to the Pentaho Server.
+ *
+ * @see IReadAccess
+ */
+public class RemoteReadAccess implements IReadAccess {
+  public static final String URI_PATH_SEPARATOR = "/";
+  protected Client client;
+  private static final Log logger = LogFactory.getLog( RemoteReadAccess.class );
+  String reposURL;
+
+  protected String basePath = RepositoryFile.SEPARATOR;
+
+  public RemoteReadAccess( String reposURL, String username, String password ) {
+    this.reposURL = reposURL;
+    ClientConfig clientConfig = new DefaultClientConfig();
+    clientConfig.getFeatures().put( JSONConfiguration.FEATURE_POJO_MAPPING, Boolean.TRUE );
+    client = Client.create( clientConfig );
+    client.addFilter( new HTTPBasicAuthFilter( username, password ) );
+  }
+
+  public RemoteReadAccess( String basePath, String reposURL, String username, String password ) {
+    this( reposURL, username, password );
+    this.basePath = ( basePath == null || basePath.isEmpty() ) ? RepositoryFile.SEPARATOR : ( basePath.endsWith( RepositoryFile.SEPARATOR ) ? basePath : basePath + RepositoryFile.SEPARATOR );
+  }
+
+  @Override
+  public InputStream getFileInputStream( String path ) throws IOException {
+    // download method used because it does the correct conversions for ktr/kjb files (see CDA-93)
+    String fullPath = buildPath( path );
+    String requestURL = createRequestURL( fullPath, "download" );
+
+    ClientResponse clientResponse = client.resource( requestURL )
+      .queryParam( "withManifest", "false" )
+      .type( MediaType.APPLICATION_OCTET_STREAM_TYPE )
+      .get( ClientResponse.class );
+
+    if ( clientResponse != null && clientResponse.getStatus() == ClientResponse.Status.OK.getStatusCode() ) {
+      return clientResponse.getEntityInputStream();
+    }
+    return null;
+  }
+
+  @Override
+  public boolean fileExists( String path ) {
+    String fullPath = buildPath( path );
+    String requestURL = createRequestURL( fullPath, "properties" );
+
+    RepositoryFileDto response = client.resource( requestURL )
+      .type( MediaType.APPLICATION_XML )
+      .get( RepositoryFileDto.class );
+
+    return response != null;
+  }
+
+  @Override
+  public long getLastModified( String path ) {
+    String fullPath = buildPath( path );
+    String requestURL = createRequestURL( fullPath, "properties" );
+    RepositoryFileDto response = client.resource( requestURL )
+      .type( MediaType.APPLICATION_XML )
+      .get( RepositoryFileDto.class );
+
+    if ( response == null ) {
+      return 0L;
+    }
+    return Long.parseLong( response.getLastModifiedDate() );
+  }
+
+  @Override
+  public List<IBasicFile> listFiles( String path, IBasicFileFilter filter, int maxDepth, boolean includeDirs, boolean showHiddenFilesAndFolders ) {
+    String fullPath = buildPath( path );
+    String requestURL = createRequestURL( fullPath, "tree" );
+
+    WebResource resource = client.resource( requestURL );
+
+    // apply query params
+    resource = resource.queryParam( "showHidden", Boolean.toString( showHiddenFilesAndFolders ) );
+
+    if ( maxDepth >= 0 ) {
+      resource = resource.queryParam( "depth", Integer.toString( maxDepth ) );
+    }
+    // NOTE: legacy filters on the "tree" endpoint do not appear to work as expected
+    //       for now, we're going to do the filtering locally.
+    /*
+    if ( !includeDirs ) {
+      target = target.queryParam( "filter", "*|FILES" );
+    }
+    */
+
+    // GET
+    RepositoryFileTreeDto response = null;
+    try {
+      response = resource.type( MediaType.APPLICATION_XML ).get( RepositoryFileTreeDto.class );
+    } catch ( Exception ex ) {
+      logger.error( ex );
+      return null;
+    }
+    if ( response == null ) {
+      return null;
+    }
+
+    return treeFlatten( response, includeDirs, filter, path );
+  }
+
+  @Override
+  public List<IBasicFile> listFiles( String path, IBasicFileFilter filter, int maxDepth, boolean includeDirs ) {
+    return listFiles( path, filter, maxDepth, includeDirs, false );
+  }
+
+  @Override
+  public List<IBasicFile> listFiles( String path, IBasicFileFilter filter, int maxDepth ) {
+    return listFiles( path, filter, maxDepth, false );
+  }
+
+  @Override
+  public List<IBasicFile> listFiles( String path, IBasicFileFilter filter ) {
+    return listFiles( path, filter, -1 );
+  }
+
+  @Override
+  public IBasicFile fetchFile( String path ) {
+    String fullPath = buildPath( path );
+    String requestURL = createRequestURL( fullPath, "properties" );
+    RepositoryFileDto response = client.resource( requestURL )
+      .type( MediaType.APPLICATION_XML )
+      .get( RepositoryFileDto.class );
+    return new RemoteBasicFile( this, response );
+  }
+
+  static String encodePath( String path ) {
+    return path.replaceAll( RepositoryFile.SEPARATOR, ":" );
+  }
+
+  String createRequestURL( String path, String method ) {
+    return createRequestURL( "/api/repo/files/", path, method );
+  }
+
+  String createRequestURL( String endpoint, String path, String method ) {
+    if ( method != null ) {
+      return reposURL + endpoint + encodePath( path ) + URI_PATH_SEPARATOR + method;
+    }
+    return reposURL + endpoint + encodePath( path );
+  }
+
+  private boolean pathEquals( String path1, String path2 ) {
+    if ( !path1.endsWith( RepositoryFile.SEPARATOR ) ) {
+      path1 = path1 + RepositoryFile.SEPARATOR;
+    }
+    if ( !path2.endsWith( RepositoryFile.SEPARATOR ) ) {
+      path2 = path2 + RepositoryFile.SEPARATOR;
+    }
+    return path1.equals( path2 );
+  }
+
+  private void treeFlattenRecursive(RepositoryFileTreeDto node, boolean includeDirs, IBasicFileFilter filter, List<IBasicFile> result, String queryPath ) {
+    IBasicFile file = new RemoteBasicFile( this, node.getFile() );
+
+    if ( ( includeDirs || !file.isDirectory() ) && !pathEquals( file.getFullPath(), queryPath ) && ( filter == null || filter.accept( file ) ) ) {
+      result.add( file );
+    }
+
+    for ( RepositoryFileTreeDto child : node.getChildren() ) {
+      treeFlattenRecursive( child, includeDirs, filter, result, queryPath );
+    }
+  }
+
+  List<IBasicFile> treeFlatten( RepositoryFileTreeDto tree, boolean includeDirs, IBasicFileFilter filter, String queryPath ) {
+    List<IBasicFile> flatList = new ArrayList<>();
+    treeFlattenRecursive( tree, includeDirs, filter, flatList, queryPath );
+    return flatList;
+  }
+
+  protected String buildPath( String path ) {
+    if ( path == null ) {
+      return this.basePath;
+    }
+
+    String fullPath = this.basePath;
+    if ( path.startsWith( RepositoryFile.SEPARATOR ) ) {
+      fullPath += path.substring( 1 );
+    } else {
+      fullPath += path;
+    }
+
+    return fullPath; //TODO: normalize and guard against accessing above basePath
+  }
+}

--- a/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteRepositoryAccessFactory.java
+++ b/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteRepositoryAccessFactory.java
@@ -13,16 +13,20 @@
 
 package pt.webdetails.cpf.repository.rca;
 
-
-import org.pentaho.ctools.cpf.repository.rca.RemoteReadAccess;
-import org.pentaho.ctools.cpf.repository.rca.RemoteReadWriteAccess;
-import org.pentaho.ctools.cpf.repository.rca.RemoteUserContentAccess;
 import pt.webdetails.cpf.api.IUserContentAccessExtended;
 import pt.webdetails.cpf.repository.api.IRWAccess;
 import pt.webdetails.cpf.repository.api.IReadAccess;
 import pt.webdetails.cpf.repository.api.IRepositoryAccessFactory;
 import pt.webdetails.cpf.repository.util.RepositoryHelper;
 
+/**
+ * Class {@code RemoteRepositoryAccessFactory} provides an implementation of {@code IRepositoryAccessFactory} via REST calls to the Pentaho Server.
+ *
+ * @see IRepositoryAccessFactory
+ * @see IUserContentAccessExtended
+ * @see IReadAccess
+ * @see IRWAccess
+ */
 public class RemoteRepositoryAccessFactory implements IRepositoryAccessFactory {
 
   private final String USERNAME = System.getProperty( "repos.user" );
@@ -45,6 +49,4 @@ public class RemoteRepositoryAccessFactory implements IRepositoryAccessFactory {
     basePath = RepositoryHelper.appendPath( pluginRepositoryDir, basePath );
     return new RemoteReadWriteAccess( basePath, URI, USERNAME, PASSWORD );
   }
-
-
 }

--- a/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteRepositoryAccessFactory.java
+++ b/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteRepositoryAccessFactory.java
@@ -11,7 +11,7 @@
  * the license for the specific language governing your rights and limitations.
  */
 
-package pt.webdetails.cpf;
+package pt.webdetails.cpf.repository.rca;
 
 
 import org.pentaho.ctools.cpf.repository.rca.RemoteReadAccess;
@@ -23,7 +23,7 @@ import pt.webdetails.cpf.repository.api.IReadAccess;
 import pt.webdetails.cpf.repository.api.IRepositoryAccessFactory;
 import pt.webdetails.cpf.repository.util.RepositoryHelper;
 
-public class RemotePentahoPluginEnvironment implements IRepositoryAccessFactory {
+public class RemoteRepositoryAccessFactory implements IRepositoryAccessFactory {
 
   private final String USERNAME = System.getProperty( "repos.user" );
   private final String PASSWORD = System.getProperty( "repos.password" );

--- a/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteRepositoryAccessFactory.java
+++ b/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteRepositoryAccessFactory.java
@@ -40,12 +40,14 @@ public class RemoteRepositoryAccessFactory implements IRepositoryAccessFactory {
 
   @Override
   public IReadAccess getPluginRepositoryReader( String pluginRepositoryDir, String basePath ) {
+    // credentials for this method should always be that of an administrator account!
     basePath = RepositoryHelper.appendPath( pluginRepositoryDir, basePath );
     return new RemoteReadAccess( basePath, URI, USERNAME, PASSWORD );
   }
 
   @Override
   public IRWAccess getPluginRepositoryWriter( String pluginRepositoryDir, String basePath ) {
+    // credentials for this method should always be that of an administrator account!
     basePath = RepositoryHelper.appendPath( pluginRepositoryDir, basePath );
     return new RemoteReadWriteAccess( basePath, URI, USERNAME, PASSWORD );
   }

--- a/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteUserContentAccess.java
+++ b/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteUserContentAccess.java
@@ -86,7 +86,7 @@ public class RemoteUserContentAccess extends RemoteReadWriteAccess implements IU
       response = client
         .resource( requestURL )
         .queryParam( "permissions", Integer.toString( encodeFileAccess( access ) ) )
-        .type( MediaType.APPLICATION_XML )
+        .type( MediaType.TEXT_PLAIN )
         .get( String.class );
     } catch ( Exception ex ) {
       logger.error( ex );

--- a/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteUserContentAccess.java
+++ b/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteUserContentAccess.java
@@ -10,8 +10,10 @@
  * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
  * the license for the specific language governing your rights and limitations.
  */
-package org.pentaho.ctools.cpf.repository.rca;
 
+package pt.webdetails.cpf.repository.rca;
+
+import com.sun.jersey.api.client.ClientResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
@@ -20,21 +22,12 @@ import pt.webdetails.cpf.api.IFileContent;
 import pt.webdetails.cpf.api.IUserContentAccessExtended;
 import pt.webdetails.cpf.repository.api.FileAccess;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Class {@code RemoteUserContentAccess} provides an implementation of {@code IUserContentAccessExtended} via REST calls to the Pentaho Server.
- *
- * @see IUserContentAccessExtended
- */
 public class RemoteUserContentAccess extends RemoteReadWriteAccess implements IUserContentAccessExtended {
-
   private static final Log logger = LogFactory.getLog( RemoteReadWriteAccess.class );
 
   public RemoteUserContentAccess( String reposURL, String username, String password ) {
@@ -46,15 +39,53 @@ public class RemoteUserContentAccess extends RemoteReadWriteAccess implements IU
   }
 
   @Override
-  public boolean hasAccess( String filePath, FileAccess access ) {
+  public boolean saveFile(IFileContent file) {
+    try {
+      if ( saveFile( file.getPath(), file.getContents() ) ) {
+        if ( file.isHidden() ) {
+          String path = file.getPath();
+          String fullPath = buildPath( path );
+          return makeHidden( fullPath ) && updateProperties( file );
+        } else {
+          return updateProperties( file );
+        }
+      }
+    } catch ( IOException ex ) {
+      logger.error( ex );
+    }
+    return false;
+  }
+
+  private boolean updateProperties( IFileContent file ) {
+    final String defaultLocale = "default"; // use default locale
+    List<StringKeyStringValueDto> properties = new ArrayList<>();
+    properties.add( new StringKeyStringValueDto( "file.title", file.getTitle() ) );
+    properties.add( new StringKeyStringValueDto( "file.description", file.getDescription() ) );
+
+    String path = file.getPath();
+    String fullPath = buildPath( path );
+    String requestURL = createRequestURL( "/api/repo/files/", fullPath, "localeProperties" );
+
+    ClientResponse response = client.resource( requestURL )
+      .queryParam( "locale", defaultLocale )
+      .type( MediaType.APPLICATION_XML )
+      .put( ClientResponse.class, properties );
+
+    //TODO: handle non-OK status codes? log? exception?
+    return response.getStatus() == ClientResponse.Status.OK.getStatusCode();
+  }
+
+  @Override
+  public boolean hasAccess(String filePath, FileAccess access) {
     String requestURL = createRequestURL( filePath, "canAccess" );
 
     String response = null;
     try {
       response = client
-        .target( requestURL )
-        .queryParam( "permissions", encodeFileAccess( access ) )
-        .request( MediaType.APPLICATION_XML ).get( String.class );
+        .resource( requestURL )
+        .queryParam( "permissions", Integer.toString( encodeFileAccess( access ) ) )
+        .type( MediaType.APPLICATION_XML )
+        .get( String.class );
     } catch ( Exception ex ) {
       logger.error( ex );
       return false;
@@ -83,44 +114,5 @@ public class RemoteUserContentAccess extends RemoteReadWriteAccess implements IU
     }
 
     return permission;
-  }
-
-  @Override
-  public boolean saveFile( IFileContent file ) {
-    try {
-      if ( saveFile( file.getPath(), file.getContents() ) ) {
-        if ( file.isHidden() ) {
-          String path = file.getPath();
-          String fullPath = buildPath( path );
-          return makeHidden( fullPath ) && updateProperties( file );
-        } else {
-          return updateProperties( file );
-        }
-      }
-    } catch ( IOException ex ) {
-      logger.error( ex );
-    }
-    return false;
-  }
-
-  private boolean updateProperties( IFileContent file ) {
-    final String defaultLocale = "default"; // use default locale
-    List<StringKeyStringValueDto> properties = new ArrayList<>();
-    properties.add( new StringKeyStringValueDto( "file.title", file.getTitle() ) );
-    properties.add( new StringKeyStringValueDto( "file.description", file.getDescription() ) );
-
-    GenericEntity<List<StringKeyStringValueDto>> entity = new GenericEntity<List<StringKeyStringValueDto>>( properties )
-    {
-    };
-    String path = file.getPath();
-    String fullPath = buildPath( path );
-    String requestURL = createRequestURL( "/api/repo/files/", fullPath, "localeProperties" );
-    Response response = client.target( requestURL )
-      .queryParam( "locale", defaultLocale )
-      .request( MediaType.APPLICATION_XML )
-      .put( Entity.xml( entity ) );
-
-    //TODO: handle non-OK status codes? log? exception?
-    return response.getStatus() == Response.Status.OK.getStatusCode();
   }
 }

--- a/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteUserContentAccess.java
+++ b/pentaho-rca/src/main/java/pt/webdetails/cpf/repository/rca/RemoteUserContentAccess.java
@@ -23,6 +23,8 @@ import pt.webdetails.cpf.api.IUserContentAccessExtended;
 import pt.webdetails.cpf.repository.api.FileAccess;
 
 import javax.ws.rs.core.MediaType;
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +47,7 @@ public class RemoteUserContentAccess extends RemoteReadWriteAccess implements IU
         if ( file.isHidden() ) {
           String path = file.getPath();
           String fullPath = buildPath( path );
-          return makeHidden( fullPath ) && updateProperties( file );
+          return putMetadataProperty( fullPath, METADATA_PERM_HIDDEN, "true" ) && updateProperties( file );
         } else {
           return updateProperties( file );
         }
@@ -58,7 +60,7 @@ public class RemoteUserContentAccess extends RemoteReadWriteAccess implements IU
 
   private boolean updateProperties( IFileContent file ) {
     final String defaultLocale = "default"; // use default locale
-    List<StringKeyStringValueDto> properties = new ArrayList<>();
+    ArrayList<StringKeyStringValueDto> properties = new ArrayList<>();
     properties.add( new StringKeyStringValueDto( "file.title", file.getTitle() ) );
     properties.add( new StringKeyStringValueDto( "file.description", file.getDescription() ) );
 
@@ -69,7 +71,7 @@ public class RemoteUserContentAccess extends RemoteReadWriteAccess implements IU
     ClientResponse response = client.resource( requestURL )
       .queryParam( "locale", defaultLocale )
       .type( MediaType.APPLICATION_XML )
-      .put( ClientResponse.class, properties );
+      .put( ClientResponse.class, new JAXBElement<>( new QName( "stringKeyStringValueDtoes" ), ArrayList.class, properties  ) );
 
     //TODO: handle non-OK status codes? log? exception?
     return response.getStatus() == ClientResponse.Status.OK.getStatusCode();

--- a/pentaho/src/main/java/pt/webdetails/cpf/PentahoPluginEnvironment.java
+++ b/pentaho/src/main/java/pt/webdetails/cpf/PentahoPluginEnvironment.java
@@ -15,7 +15,6 @@ package pt.webdetails.cpf;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 
 import pt.webdetails.cpf.api.IContentAccessFactoryExtended;
 import pt.webdetails.cpf.api.IUserContentAccessExtended;
@@ -23,9 +22,8 @@ import pt.webdetails.cpf.context.api.IUrlProvider;
 import pt.webdetails.cpf.plugincall.api.IPluginCall;
 import pt.webdetails.cpf.repository.api.IRWAccess;
 import pt.webdetails.cpf.repository.api.IReadAccess;
-import pt.webdetails.cpf.repository.pentaho.unified.PluginRepositoryResourceAccess;
-import pt.webdetails.cpf.repository.pentaho.unified.UserContentRepositoryAccess;
-import pt.webdetails.cpf.repository.util.RepositoryHelper;
+import pt.webdetails.cpf.repository.api.IRepositoryAccessFactory;
+import pt.webdetails.cpf.repository.pentaho.unified.UnifiedRepositoryAccessFactory;
 
 //TODO: there must be another singleton
 public class PentahoPluginEnvironment extends PentahoBasePluginEnvironment implements IContentAccessFactoryExtended {
@@ -33,6 +31,7 @@ public class PentahoPluginEnvironment extends PentahoBasePluginEnvironment imple
   private static PentahoPluginEnvironment instance = new PentahoPluginEnvironment();
   private IUrlProvider pentahoUrlProvider;
   private static Log logger = LogFactory.getLog( PentahoPluginEnvironment.class );
+  private IRepositoryAccessFactory repositoryAccessFactory = new UnifiedRepositoryAccessFactory();
 
   static {
     PluginEnvironment.init( instance );
@@ -51,19 +50,17 @@ public class PentahoPluginEnvironment extends PentahoBasePluginEnvironment imple
 
   @Override
   public IUserContentAccessExtended getUserContentAccess( String basePath ) {
-    return new UserContentRepositoryAccess( PentahoSessionHolder.getSession(), basePath );
+    return repositoryAccessFactory.getUserContentAccess( basePath );
   }
 
   @Override
   public IReadAccess getPluginRepositoryReader( String basePath ) {
-    basePath = RepositoryHelper.appendPath( getPluginRepositoryDir(), basePath );
-    return new PluginRepositoryResourceAccess( basePath );
+    return repositoryAccessFactory.getPluginRepositoryReader( getPluginRepositoryDir(), basePath );
   }
 
   @Override
   public IRWAccess getPluginRepositoryWriter( String basePath ) {
-    basePath = RepositoryHelper.appendPath( getPluginRepositoryDir(), basePath );
-    return new PluginRepositoryResourceAccess( basePath );
+    return repositoryAccessFactory.getPluginRepositoryWriter( getPluginRepositoryDir(), basePath );
   }
 
   @Override
@@ -77,6 +74,10 @@ public class PentahoPluginEnvironment extends PentahoBasePluginEnvironment imple
   @Override
   public IPluginCall getPluginCall( String pluginId, String servicePath, String method ) {
     return new InterPluginCall( new InterPluginCall.Plugin( pluginId ), servicePath, method );
+  }
+
+  public void setRepositoryAccessFactory( IRepositoryAccessFactory factory ) {
+    this.repositoryAccessFactory = factory;
   }
 
 }

--- a/pentaho/src/main/java/pt/webdetails/cpf/repository/pentaho/unified/UnifiedRepositoryAccessFactory.java
+++ b/pentaho/src/main/java/pt/webdetails/cpf/repository/pentaho/unified/UnifiedRepositoryAccessFactory.java
@@ -1,0 +1,43 @@
+/*!
+ * Copyright 2018 Webdetails, a Hitachi Vantara company. All rights reserved.
+ *
+ * This software was developed by Webdetails and is provided under the terms
+ * of the Mozilla Public License, Version 2.0, or any later version. You may not use
+ * this file except in compliance with the license. If you need a copy of the license,
+ * please go to http://mozilla.org/MPL/2.0/. The Initial Developer is Webdetails.
+ *
+ * Software distributed under the Mozilla Public License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. Please refer to
+ * the license for the specific language governing your rights and limitations.
+ */
+
+package pt.webdetails.cpf.repository.pentaho.unified;
+
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import pt.webdetails.cpf.api.IUserContentAccessExtended;
+import pt.webdetails.cpf.repository.api.IRWAccess;
+import pt.webdetails.cpf.repository.api.IReadAccess;
+import pt.webdetails.cpf.repository.api.IRepositoryAccessFactory;
+import pt.webdetails.cpf.repository.util.RepositoryHelper;
+
+/**
+ * Class {@code UnifiedRepositoryAccessFactor} implements {@code IRepositoryAccessFactory} via Unified Repository.
+ */
+public class UnifiedRepositoryAccessFactory implements IRepositoryAccessFactory {
+  @Override
+  public IUserContentAccessExtended getUserContentAccess( String basePath ) {
+    return new UserContentRepositoryAccess( PentahoSessionHolder.getSession(), basePath );
+  }
+
+  @Override
+  public IReadAccess getPluginRepositoryReader( String pluginRepositoryDir, String basePath ) {
+    basePath = RepositoryHelper.appendPath( pluginRepositoryDir, basePath );
+    return new PluginRepositoryResourceAccess( basePath );
+  }
+
+  @Override
+  public IRWAccess getPluginRepositoryWriter( String pluginRepositoryDir, String basePath ) {
+    basePath = RepositoryHelper.appendPath( pluginRepositoryDir, basePath );
+    return new PluginRepositoryResourceAccess( basePath );
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <module>assemblies</module>
     <module>core</module>
     <module>pentaho</module>
+    <module>pentaho-rca</module>
     <module>osgi</module>
     <module>rca</module>
   </modules>

--- a/rca/src/main/java/org/pentaho/ctools/cpf/repository/rca/RemoteBasicFile.java
+++ b/rca/src/main/java/org/pentaho/ctools/cpf/repository/rca/RemoteBasicFile.java
@@ -15,6 +15,7 @@ package org.pentaho.ctools.cpf.repository.rca;
 import org.pentaho.platform.api.repository2.unified.webservices.RepositoryFileDto;
 import pt.webdetails.cpf.repository.api.IBasicFile;
 import pt.webdetails.cpf.repository.api.IReadAccess;
+import pt.webdetails.cpf.repository.util.RepositoryHelper;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,15 +28,17 @@ import java.io.InputStream;
 public class RemoteBasicFile implements IBasicFile {
   IReadAccess remote;
   RepositoryFileDto repositoryFile;
+  String relativePath;
 
-  public RemoteBasicFile( IReadAccess remote, RepositoryFileDto dto ) {
+  public RemoteBasicFile( String basePath, IReadAccess remote, RepositoryFileDto dto ) {
     this.remote = remote;
     repositoryFile = dto;
+    relativePath = RepositoryHelper.relativizePath( basePath, repositoryFile.getPath(), true );
   }
 
   @Override
   public InputStream getContents() throws IOException {
-    return remote.getFileInputStream( repositoryFile.getPath() );
+    return remote.getFileInputStream( getPath() );
   }
 
   @Override
@@ -45,12 +48,12 @@ public class RemoteBasicFile implements IBasicFile {
 
   @Override
   public String getFullPath() {
-    return repositoryFile.getPath(); // TODO: validate, do we need to append some basePath from UserContentAccess?
+    return repositoryFile.getPath();
   }
 
   @Override
   public String getPath() {
-    return repositoryFile.getPath();
+    return relativePath;
   }
 
   @Override

--- a/rca/src/main/java/org/pentaho/ctools/cpf/repository/rca/RemoteBasicFile.java
+++ b/rca/src/main/java/org/pentaho/ctools/cpf/repository/rca/RemoteBasicFile.java
@@ -63,7 +63,7 @@ public class RemoteBasicFile implements IBasicFile {
       return path;
     }
     final int index = path.lastIndexOf( "." );
-    if ( index == -1 ) {
+    if ( index <= 0 ) {
       return "";
     }
     return path.substring( index + 1 );

--- a/rca/src/main/java/org/pentaho/ctools/cpf/repository/rca/RemoteReadAccess.java
+++ b/rca/src/main/java/org/pentaho/ctools/cpf/repository/rca/RemoteReadAccess.java
@@ -142,7 +142,7 @@ public class RemoteReadAccess implements IReadAccess {
       return null;
     }
 
-    return treeFlatten( response, includeDirs, filter, path );
+    return treeFlatten( response, includeDirs, filter, fullPath );
   }
 
   @Override
@@ -167,7 +167,7 @@ public class RemoteReadAccess implements IReadAccess {
     RepositoryFileDto response = client.target( requestURL )
         .request( MediaType.APPLICATION_XML )
         .get( RepositoryFileDto.class );
-    return new RemoteBasicFile( this, response );
+    return new RemoteBasicFile( basePath, this, response );
   }
 
   static String encodePath( String path ) {
@@ -196,7 +196,7 @@ public class RemoteReadAccess implements IReadAccess {
   }
 
   private void treeFlattenRecursive( RepositoryFileTreeDto node, boolean includeDirs, IBasicFileFilter filter, List<IBasicFile> result, String queryPath ) {
-    IBasicFile file = new RemoteBasicFile( this, node.getFile() );
+    IBasicFile file = new RemoteBasicFile( basePath, this, node.getFile() );
 
     if ( ( includeDirs || !file.isDirectory() ) && !pathEquals( file.getFullPath(), queryPath ) && ( filter == null || filter.accept( file ) ) ) {
       result.add( file );

--- a/rca/src/main/java/org/pentaho/ctools/cpf/repository/rca/RemoteUserContentAccess.java
+++ b/rca/src/main/java/org/pentaho/ctools/cpf/repository/rca/RemoteUserContentAccess.java
@@ -35,6 +35,10 @@ public class RemoteUserContentAccess extends RemoteReadWriteAccess implements IU
     super( reposURL, username, password );
   }
 
+  public RemoteUserContentAccess( String basePath, String reposURL, String username, String password ) {
+    super( basePath, reposURL, username, password );
+  }
+
   @Override
   public boolean hasAccess( String filePath, FileAccess access ) {
     //TODO: dummy implementation
@@ -46,7 +50,9 @@ public class RemoteUserContentAccess extends RemoteReadWriteAccess implements IU
     try {
       if ( saveFile( file.getPath(), file.getContents() ) ) {
         if ( file.isHidden() ) {
-          return makeHidden( file.getPath() ) && updateProperties( file );
+          String path = file.getPath();
+          String fullPath = buildPath( path );
+          return makeHidden( fullPath ) && updateProperties( file );
         } else {
           return updateProperties( file );
         }
@@ -66,8 +72,9 @@ public class RemoteUserContentAccess extends RemoteReadWriteAccess implements IU
     GenericEntity<List<StringKeyStringValueDto>> entity = new GenericEntity<List<StringKeyStringValueDto>>( properties )
     {
     };
-
-    String requestURL = createRequestURL( "/api/repo/files/", file.getPath(), "localeProperties" );
+    String path = file.getPath();
+    String fullPath = buildPath( path );
+    String requestURL = createRequestURL( "/api/repo/files/", fullPath, "localeProperties" );
     Response response = client.target( requestURL )
       .queryParam( "locale", defaultLocale )
       .request( MediaType.APPLICATION_XML )

--- a/rca/src/main/java/org/pentaho/ctools/cpf/repository/rca/RemoteUserContentAccess.java
+++ b/rca/src/main/java/org/pentaho/ctools/cpf/repository/rca/RemoteUserContentAccess.java
@@ -54,7 +54,7 @@ public class RemoteUserContentAccess extends RemoteReadWriteAccess implements IU
       response = client
         .target( requestURL )
         .queryParam( "permissions", encodeFileAccess( access ) )
-        .request( MediaType.APPLICATION_XML ).get( String.class );
+        .request( MediaType.TEXT_PLAIN ).get( String.class );
     } catch ( Exception ex ) {
       logger.error( ex );
       return false;


### PR DESCRIPTION
Makes the following changes to CPF:
- refactor cpf-pentaho to allow replacing the repository access
- create cpf-pentaho-rca that replaces the default repository access with calls to RCA
- create a new non-OSGi RCA implementation based on JAX-RS 1.x (platform is on Jersey 1.x)
- various improvements to RCA in terms of access control, relative path handling and extension detection
