### PR TITLE
[CLEANUP] Re-add checked exception to CPF's SimpleLifecycleListener, …

### DIFF
--- a/pentaho/src/main/java/pt/webdetails/cpf/SimpleLifeCycleListener.java
+++ b/pentaho/src/main/java/pt/webdetails/cpf/SimpleLifeCycleListener.java
@@ -40,7 +40,7 @@ public abstract class SimpleLifeCycleListener implements IPluginLifecycleListene
   }
 
   @Override
-  public void ready() {
+  public void ready() throws PluginLifecycleException {
     final CpfProperties cpfProperties = CpfProperties.getInstance();
 
     final boolean usePersistence = cpfProperties.getBooleanProperty( "USE_PERSISTENCE", false );


### PR DESCRIPTION
…to not break subclasses of it such as CdaLifecycleListener

- addendum to https://github.com/webdetails/cpf/pull/145 , given that builds are failing with 

> 04:24:30  /build2/thanos/workspace/9.0/suite-release/builds/webdetails.cda.master/pentaho/src/main/java/pt/webdetails/cda/CdaLifecycleListener.java:[77,25] ready() in pt.webdetails.cda.CdaLifecycleListener cannot override ready() in pt.webdetails.cpf.SimpleLifeCycleListener
04:24:30    overridden method does not throw org.pentaho.platform.api.engine.PluginLifecycleException

( http://thanos.pentaho.net/job/9.0/job/suite-release-jobs/job/cda-plugin/55/console )

@davidmsantos90 @graimundo @jmcrfp 