### PR TITLE
[BACKLOG-30893] Centralize commons-logging in parent pom

### DIFF
--- a/assemblies/cpf-pdi/pom.xml
+++ b/assemblies/cpf-pdi/pom.xml
@@ -29,7 +29,6 @@
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>${commons-logging.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
     <powermock.version>1.7.3</powermock.version>
     <commons-vfs.version>1.0</commons-vfs.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
-    <commons-logging.version>1.1.1</commons-logging.version>
     <commons-io.version>2.1</commons-io.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-lang.version>2.6</commons-lang.version>
@@ -72,11 +71,6 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${commons-io.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>${commons-logging.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
Linked with this: pentaho/maven-parent-poms#163