### PR TITLE
[BACKLOG-41287]-Upgrading Cpf from Java EE to Jakarta EE to be compatiable with Tomcat-10.X

### DIFF
--- a/pentaho/src/main/java/pt/webdetails/cpf/web/CpfHttpServletRequest.java
+++ b/pentaho/src/main/java/pt/webdetails/cpf/web/CpfHttpServletRequest.java
@@ -14,6 +14,7 @@ import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
 import java.util.*;
+import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
@@ -658,7 +659,6 @@ public class CpfHttpServletRequest implements HttpServletRequest {
         return new CpfRequestDispatcher(path);
     }
 
-    @Override
     public String getRealPath(String path) {
         return this.servletContext.getRealPath(path);
     }
@@ -729,6 +729,21 @@ public class CpfHttpServletRequest implements HttpServletRequest {
 
     @Override
     public DispatcherType getDispatcherType() {
+        return null;
+    }
+
+    @Override
+    public String getRequestId() {
+        return null;
+    }
+
+    @Override
+    public String getProtocolRequestId() {
+        return null;
+    }
+
+    @Override
+    public ServletConnection getServletConnection() {
         return null;
     }
 

--- a/pentaho/src/main/java/pt/webdetails/cpf/web/CpfHttpSession.java
+++ b/pentaho/src/main/java/pt/webdetails/cpf/web/CpfHttpSession.java
@@ -19,7 +19,6 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.HttpSessionBindingEvent;
 import jakarta.servlet.http.HttpSessionBindingListener;
-import jakarta.servlet.http.HttpSessionContext;
 
 import org.springframework.util.Assert;
 
@@ -74,10 +73,6 @@ public class CpfHttpSession implements HttpSession {
 
     public int getMaxInactiveInterval() {
        return this.maxInactiveInterval;
-    }
-
-    public HttpSessionContext getSessionContext() {
-       throw new UnsupportedOperationException("getSessionContext");
     }
 
     public Object getAttribute(String name) {

--- a/pentaho/src/main/java/pt/webdetails/cpf/web/CpfServletContext.java
+++ b/pentaho/src/main/java/pt/webdetails/cpf/web/CpfServletContext.java
@@ -195,28 +195,8 @@ class CpfServletContext implements ServletContext {
   }
 
   @Override
-  public Servlet getServlet( String string ) throws ServletException {
-    throw new UnsupportedOperationException( "Not supported yet." );
-  }
-
-  @Override
-  public Enumeration getServlets(  ) {
-    throw new UnsupportedOperationException( "Not supported yet." );
-  }
-
-  @Override
-  public Enumeration getServletNames(  ) {
-    throw new UnsupportedOperationException( "Not supported yet." );
-  }
-
-  @Override
   public void log( String message ) {
     logger.info( message );
-  }
-
-  @Override
-  public void log( Exception ex, String message ) {
-    logger.info( message, ex );
   }
 
   @Override


### PR DESCRIPTION
[BACKLOG-41287]-Upgrading Cpf from Java EE to Jakarta EE to be compatiable with Tomcat-10.X

[BACKLOG-41287]: https://hv-eng.atlassian.net/browse/BACKLOG-41287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ