### PR TITLE
fix: add new methods to MondrianCatalogServiceMock

### DIFF
--- a/pentaho/src/test/java/pt/webdetails/cpf/olap/MondrianCatalogServiceMock.java
+++ b/pentaho/src/test/java/pt/webdetails/cpf/olap/MondrianCatalogServiceMock.java
@@ -19,13 +19,11 @@ import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalog;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCatalogServiceException;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianCube;
 import org.pentaho.platform.plugin.action.mondrian.catalog.MondrianSchema;
-import org.pentaho.platform.util.FileHelper;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public class MondrianCatalogServiceMock implements IMondrianCatalogService {
   @Override


### PR DESCRIPTION
Add methods that were added in https://github.com/pentaho/pentaho-platform/pull/5908 to MondrianCatalogServiceMock 